### PR TITLE
fix(NameError) add msg param in check methods, by default None

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,8 @@ Usage
 
 Test results:
 
-.. code-block:: bash
+.. code-block:: python
+
     FAILURE: Must be equal part one
       test_one.py, line 6, in test_one() -> check.equal(1, 2, 'Must be equal part one')
     AssertionError
@@ -96,7 +97,8 @@ For example test code:
 
 Test results:
 
-.. code-block:: bash
+.. code-block:: python
+
     FAILURE: Must be equal, functional is bad
       test_one.py, line 13, in test_two() -> self.check.equal(1, 2, 'Must be equal, functional is bad')
     AssertionError

--- a/README.rst
+++ b/README.rst
@@ -50,8 +50,6 @@ Usage
 Test results:
 
 .. code-block:: bash
-    ================================== FAILURES ==================================
-    __________________________________ test_one __________________________________
     FAILURE: Must be equal part one
       test_one.py, line 6, in test_one() -> check.equal(1, 2, 'Must be equal part one')
     AssertionError
@@ -64,6 +62,7 @@ Test results:
     Failed Checks: 2
 
 **Or use some test case class**
+
 For example test case code:
 
 .. code-block:: python
@@ -75,9 +74,11 @@ For example test case code:
 
         check = None
 
-        @pytest.fixture(scope='function', autouse=True)
+        @pytest.yield_fixture(scope='function', autouse=True)
         def setup(self, check):
             self.check = check
+            yield self.check
+            self.check = None
 
 
 For example test code:
@@ -96,8 +97,6 @@ For example test code:
 Test results:
 
 .. code-block:: bash
-    ================================== FAILURES ==================================
-    ______________________________ TestTwo.test_two ______________________________
     FAILURE: Must be equal, functional is bad
       test_one.py, line 13, in test_two() -> self.check.equal(1, 2, 'Must be equal, functional is bad')
     AssertionError
@@ -107,6 +106,7 @@ Test results:
 
 
 **Exist validations:**
+
 - check.equal *a == b*
 - check.not_equal *a != b*
 - check.is_true *bool(x) is True*

--- a/README.rst
+++ b/README.rst
@@ -107,23 +107,23 @@ Test results:
 
 **Exist validations:**
 
-- check.equal *a == b*
-- check.not_equal *a != b*
-- check.is_true *bool(x) is True*
-- check.is_false *bool(x) is False*
-- check.is_not *a is not b*
-- check.is_none *x is None*
-- check.is_not_none *x is not None*
-- check.is_in *a in b*
-- check.not_in *a not in b*
-- check.is_instance *isinstance(a, b)*
-- check.not_is_instance *not isinstance(a, b)*
-- check.almost_equal *a == pytest.approx(b, rel, abs)* see at: `pytest.approx <https://docs.pytest.org/en/latest/reference.html#pytest-approx>`_
-- check.not_almost_equal *a != pytest.approx(b, rel, abs)* see at: `pytest.approx <https://docs.pytest.org/en/latest/reference.html#pytest-approx>`_
-- check.greater *a > b*
-- check.greater_equal *a >= b*
-- check.less *a < b*
-- check.less_equal *a <= b*
+- **check.equal** - *a == b*
+- **check.not_equal** - *a != b*
+- **check.is_true** - *bool(x) is True*
+- **check.is_false** - *bool(x) is False*
+- **check.is_not** - *a is not b*
+- **check.is_none** - *x is None*
+- **check.is_not_none** - *x is not None*
+- **check.is_in** - *a in b*
+- **check.not_in** - *a not in b*
+- **check.is_instance** - *isinstance(a, b)*
+- **check.not_is_instance** - *not isinstance(a, b)*
+- **check.almost_equal** - *a == pytest.approx(b, rel, abs)* see at: `pytest.approx <https://docs.pytest.org/en/latest/reference.html#pytest-approx>`_
+- **check.not_almost_equal** - *a != pytest.approx(b, rel, abs)* see at: `pytest.approx <https://docs.pytest.org/en/latest/reference.html#pytest-approx>`_
+- **check.greater** - *a > b*
+- **check.greater_equal** - *a >= b*
+- **check.less** - *a < b*
+- **check.less_equal** - *a <= b*
 
 
 Contributing

--- a/README.rst
+++ b/README.rst
@@ -18,23 +18,113 @@ Features
 Requirements
 ------------
 
-* TODO
+- pytest>=3.1.1
 
 
 Installation
 ------------
 
-Eventually, you'll be able to install "pytest-check" via `pip`_ from `PyPI`_::
+Eventually, you'll be able to install "pytest-check" via `pip`_ from `PyPI`_:
 
+.. code-block:: bash
     $ pip install pytest-check
 
 But for now, you'll have to install it from github.
+
+.. code-block:: bash
+    $ pip install git+https://github.com/okken/pytest-check
 
 
 Usage
 -----
 
-* TODO
+**Use as pytest fixture**
+
+.. code-block:: python
+
+    def test_one(check):
+        check.equal(1, 2, msg='Must be equal part one')
+        check.equal(1, 3)  # msg None by default
+
+
+Test results:
+
+.. code-block:: bash
+    ================================== FAILURES ==================================
+    __________________________________ test_one __________________________________
+    FAILURE: Must be equal part one
+      test_one.py, line 6, in test_one() -> check.equal(1, 2, 'Must be equal part one')
+    AssertionError
+
+    FAILURE:
+      test_one.py, line 7, in test_one() -> check.equal(1, 3, 'Must be equal part two')
+    AssertionError
+
+    ------------------------------------------------------------
+    Failed Checks: 2
+
+**Or use some test case class**
+For example test case code:
+
+.. code-block:: python
+
+    import pytest
+
+
+    class TestCase:
+
+        check = None
+
+        @pytest.fixture(scope='function', autouse=True)
+        def setup(self, check):
+            self.check = check
+
+
+For example test code:
+
+.. code-block:: python
+
+    from base import TestCase
+
+
+    class TestTwo(TestCase):
+
+        def test_two(self):
+            self.check.equal(1, 2, 'two test')
+
+
+Test results:
+
+.. code-block:: bash
+    ================================== FAILURES ==================================
+    ______________________________ TestTwo.test_two ______________________________
+    FAILURE: Must be equal, functional is bad
+      test_one.py, line 13, in test_two() -> self.check.equal(1, 2, 'Must be equal, functional is bad')
+    AssertionError
+
+    ------------------------------------------------------------
+    Failed Checks: 1
+
+
+**Exist validations:**
+- check.equal *a == b*
+- check.not_equal *a != b*
+- check.is_true *bool(x) is True*
+- check.is_false *bool(x) is False*
+- check.is_not *a is not b*
+- check.is_none *x is None*
+- check.is_not_none *x is not None*
+- check.is_in *a in b*
+- check.not_in *a not in b*
+- check.is_instance *isinstance(a, b)*
+- check.not_is_instance *not isinstance(a, b)*
+- check.almost_equal *a == pytest.approx(b, rel, abs)* see at: `pytest.approx <https://docs.pytest.org/en/latest/reference.html#pytest-approx>`_
+- check.not_almost_equal *a != pytest.approx(b, rel, abs)* see at: `pytest.approx <https://docs.pytest.org/en/latest/reference.html#pytest-approx>`_
+- check.greater *a > b*
+- check.greater_equal *a >= b*
+- check.less *a < b*
+- check.less_equal *a <= b*
+
 
 Contributing
 ------------

--- a/src/pytest_check/plugin.py
+++ b/src/pytest_check/plugin.py
@@ -6,6 +6,7 @@ import sys
 import inspect
 import os
 
+
 @pytest.fixture()
 def check(request):
     return Check(request.node)
@@ -45,61 +46,61 @@ class Check:
         except AssertionError:
             self.log_failure(msg)
 
-    def not_equal(self, a, b):
+    def not_equal(self, a, b, msg=None):
         try:
             assert a != b
         except AssertionError:
             self.log_failure(msg)
 
-    def is_true(self, x):
+    def is_true(self, x, msg=None):
         try:
             assert bool(x) is True
         except AssertionError:
             self.log_failure(msg)
 
-    def is_false(self, x):
+    def is_false(self, x, msg=None):
         try:
             assert bool(x) is False
         except AssertionError:
             self.log_failure(msg)
 
-    def is_not(self, a, b):
+    def is_not(self, a, b, msg=None):
         try:
             assert a is not b
         except AssertionError:
             self.log_failure(msg)
 
-    def is_none(self, x):
+    def is_none(self, x, msg=None):
         try:
             assert x is None
         except AssertionError:
             self.log_failure(msg)
 
-    def is_not_none(self, x):
+    def is_not_none(self, x, msg=None):
         try:
             assert x is not None
         except AssertionError:
             self.log_failure(msg)
 
-    def is_in(self, a, b):
+    def is_in(self, a, b, msg=None):
         try:
             assert a in b
         except AssertionError:
             self.log_failure(msg)
 
-    def not_in(self, a, b):
+    def not_in(self, a, b, msg=None):
         try:
             assert a not in b
         except AssertionError:
             self.log_failure(msg)
 
-    def is_instance(self, a, b):
+    def is_instance(self, a, b, msg=None):
         try:
             assert isinstance(a, b)
         except AssertionError:
             self.log_failure(msg)
 
-    def not_is_instance(self, a, b):
+    def not_is_instance(self, a, b, msg=None):
         try:
             assert not isinstance(a, b)
         except AssertionError:
@@ -111,7 +112,7 @@ class Check:
         See https://docs.pytest.org/en/latest/builtin.html#pytest.approx
         """
         try:
-            assert a == approx(b, rel, abs)
+            assert a == pytest.approx(b, rel, abs)
         except AssertionError:
             self.log_failure(msg)
 
@@ -121,7 +122,7 @@ class Check:
         See https://docs.pytest.org/en/latest/builtin.html#pytest.approx
         """
         try:
-            assert a != approx(b, rel, abs)
+            assert a != pytest.approx(b, rel, abs)
         except AssertionError:
             self.log_failure(msg)
 


### PR DESCRIPTION
fix(NameError) add msg param in check methods, by default None
add(readme) usage and requirements

Changes:
-   README.rst
-   src/pytest_check/plugin.py
