### PR TITLE
Remove extra function call from context manger API

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,19 +144,19 @@ from pytest_check import check
 
 
 def test_context_manager():
-    with check():
+    with check:
         x = 3
         assert 1 < x < 4
 ```
 
-Within any `with check():`, however, you still won't get past the assert statement,
-so you will need to use multiple `with check():` blocks for multiple asserts:
+Within any `with check:`, however, you still won't get past the assert statement,
+so you will need to use multiple `with check:` blocks for multiple asserts:
 
 ```python
     def test_multiple_failures():
-        with check(): assert 1 == 0
-        with check(): assert 1 > 2
-        with check(): assert 1 < 5 < 4
+        with check: assert 1 == 0
+        with check: assert 1 > 2
+        with check: assert 1 < 5 < 4
 
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from io import open
 from os import path
 from setuptools import setup, find_packages
 

--- a/src/pytest_check/check_methods.py
+++ b/src/pytest_check/check_methods.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 import functools
 import inspect
 import os
@@ -45,17 +44,21 @@ def set_stop_on_fail(stop_on_fail):
     _stop_on_fail = stop_on_fail
 
 
-@contextmanager
-def check():
-    __tracebackhide__ = True
-    try:
-        yield
-    except AssertionError as e:
-        if _stop_on_fail:
-            raise e
-        log_failure(e)
-    finally:
-        pass
+class CheckContextManager(object):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        __tracebackhide__ = True
+        if exc_type is not None and issubclass(exc_type, AssertionError):
+            if _stop_on_fail:
+                return
+            else:
+                log_failure(exc_val)
+                return True
+
+
+check = CheckContextManager()
 
 
 def check_func(func):

--- a/src/pytest_check/check_methods.py
+++ b/src/pytest_check/check_methods.py
@@ -181,7 +181,7 @@ def log_failure(msg):
         if 'contextlib.py' in file:
             pass
         else:
-            line = f"  {file}, line {line}, in {func}() -> {context}"
+            line = "  {}, line {}, in {}() -> {}".format(file, line, func, context)
             pseudo_trace.append(line)
         level += 1
     pseudo_trace_str = "\n".join(reversed(pseudo_trace))

--- a/tests/test_check_context_manager.py
+++ b/tests/test_check_context_manager.py
@@ -6,7 +6,7 @@ from pytest_check import check
 # flake8: noqa
 
 def test_context_manager():
-    with check():
+    with check:
         x = 3
         assert 1 < x < 4
 
@@ -17,9 +17,9 @@ def test_context_manager_fail(testdir):
         from pytest_check import check
 
         def test_failures():
-            with check(): assert 1 == 0
-            with check(): assert 1 > 2
-            with check(): assert 1 < 5 < 4
+            with check: assert 1 == 0
+            with check: assert 1 > 2
+            with check: assert 1 < 5 < 4
     """
     )
 
@@ -40,9 +40,9 @@ def test_stop_on_fail(testdir):
         from pytest_check import check
 
         def test_failures():
-            with check(): assert 1 == 0
-            with check(): assert 1 > 2
-            with check(): assert 1 < 5 < 4
+            with check: assert 1 == 0
+            with check: assert 1 > 2
+            with check: assert 1 < 5 < 4
     """
     )
 


### PR DESCRIPTION
As mentioned in https://github.com/okken/pytest-check/issues/9#issuecomment-466701960

So I still use python 2.7 🙄 

PS. How come you're not using pytest-cov?
