### PR TITLE
Adding the xfail(strict=True) support

### DIFF
--- a/src/pytest_check/plugin.py
+++ b/src/pytest_check/plugin.py
@@ -16,6 +16,9 @@ def pytest_runtest_makereport(item, call):
         if evalxfail and evalxfail.wasvalid() and evalxfail.istrue():
             report.outcome = "skipped"
             report.wasxfail = evalxfail.getexplanation()
+        elif outcome._result.longreprtext.startswith("[XPASS(strict)]"):
+            report.outcome = "skipped"
+            report.wasxfail = "\n".join(failures)
         else:
             summary = "Failed Checks: {}".format(len(failures))
             longrepr = ["\n".join(failures)]

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -178,6 +178,22 @@ def test_check_xfail(testdir):
     result.assert_outcomes(xfailed=1)
     result.stdout.fnmatch_lines(["* 1 xfailed *"])
 
+def test_check_xfail_strict(testdir):
+    testdir.makepyfile(
+        """
+        import pytest_check as check
+        import pytest
+        
+        @pytest.mark.xfail(strict=True)
+        def test_fail():
+            check.equal(1, 2)
+    """
+    )
+
+    result = testdir.runpytest()
+    result.assert_outcomes(xfailed=1)
+    result.stdout.fnmatch_lines(["* 1 xfailed *"])
+
 
 def test_check_xpassed(testdir):
     testdir.makepyfile(


### PR DESCRIPTION
Hi, 
I've been using the pytest-check tool and noticed that fail(strict=True) is not supported. 

This update has worked for me locally.

Ciao, 
derirreIre