### PR TITLE
Failure report with pattern `<filename>:<line_nr>`

### DIFF
--- a/src/pytest_check/check_methods.py
+++ b/src/pytest_check/check_methods.py
@@ -180,7 +180,7 @@ def log_failure(msg):
         (file, line, func, context) = get_full_context(level)
         if "site-packages" in file:
             break
-        line = "  {}, line {}, in {}() -> {}".format(file, line, func, context)
+        line = "{}:{} in {}() -> {}".format(file, line, func, context)
         pseudo_trace.append(line)
         level += 1
     pseudo_trace_str = "\n".join(reversed(pseudo_trace))


### PR DESCRIPTION
More details in https://github.com/okken/pytest-check/issues/21

Ran tests in tox and looks good. No need to add/modify any tests.
Didn't bump version nr (not sure if needed to).