### PR TITLE
Fix `is_not_instance` doc inconsistency in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ def test_example(check):
 - **check.is_in** - *a in b*
 - **check.is_not_in** - *a not in b*
 - **check.is_instance** - *isinstance(a, b)*
-- **check.not_is_instance** - *not isinstance(a, b)*
+- **check.is_not_instance** - *not isinstance(a, b)*
 - **check.almost_equal** - *a == pytest.approx(b, rel, abs)* see at: [pytest.approx](https://docs.pytest.org/en/latest/reference.html#pytest-approx)
 - **check.not_almost_equal** - *a != pytest.approx(b, rel, abs)* see at: [pytest.approx](https://docs.pytest.org/en/latest/reference.html#pytest-approx)
 - **check.greater** - *a > b*


### PR DESCRIPTION
The `is_not_instance` is described as `not_is_instance` in the `README.MD`, as described in #27 . This little patch is intended to fix it.