### PR TITLE
Add a "msg" parameter to check context manager

### DIFF
--- a/src/pytest_check/check_methods.py
+++ b/src/pytest_check/check_methods.py
@@ -64,6 +64,7 @@ class CheckContextManager(object):
                     log_failure(exc_val)
                 self.msg = None
                 return True
+        self.msg = None
 
     def __call__(self, msg=None):
         self.msg = msg

--- a/src/pytest_check/check_methods.py
+++ b/src/pytest_check/check_methods.py
@@ -45,6 +45,9 @@ def set_stop_on_fail(stop_on_fail):
 
 
 class CheckContextManager(object):
+
+    msg = None
+
     def __enter__(self):
         return self
 
@@ -52,10 +55,19 @@ class CheckContextManager(object):
         __tracebackhide__ = True
         if exc_type is not None and issubclass(exc_type, AssertionError):
             if _stop_on_fail:
+                self.msg = None
                 return
             else:
-                log_failure(exc_val)
+                if self.msg is not None:
+                    log_failure(self.msg)
+                else:
+                    log_failure(exc_val)
+                self.msg = None
                 return True
+
+    def __call__(self, msg=None):
+        self.msg = msg
+        return self
 
 
 check = CheckContextManager()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,2 +1,1 @@
 pytest_plugins = "pytester"
-

--- a/tests/test_check_context_manager.py
+++ b/tests/test_check_context_manager.py
@@ -10,6 +10,13 @@ def test_context_manager():
         x = 3
         assert 1 < x < 4
 
+def test_context_manager_with_msg():
+    assert check.msg is None
+    with check("Hello"):
+        assert check.msg == "Hello"
+        x = 3
+        assert 1 < x < 4
+    assert check.msg is None
 
 def test_context_manager_fail(testdir):
     testdir.makepyfile(
@@ -29,6 +36,29 @@ def test_context_manager_fail(testdir):
         "*FAILURE: assert 1 == 0*",
         "*FAILURE: assert 1 > 2*",
         "*FAILURE: assert 5 < 4*",
+        "* assert 1 < 5 < 4*",
+        "*Failed Checks: 3*",
+    ])
+
+
+def test_context_manager_with_msg(testdir):
+    testdir.makepyfile(
+        """
+        from pytest_check import check
+
+        def test_failures():
+            with check("first fail"): assert 1 == 0
+            with check("second fail"): assert 1 > 2
+            with check("third fail"): assert 1 < 5 < 4
+    """
+    )
+
+    result = testdir.runpytest()
+    result.assert_outcomes(failed=1, passed=0)
+    result.stdout.fnmatch_lines([
+        "*FAILURE: first fail*",
+        "*FAILURE: second fail*",
+        "*FAILURE: third fail*",
         "* assert 1 < 5 < 4*",
         "*Failed Checks: 3*",
     ])

--- a/tests/test_check_context_manager.py
+++ b/tests/test_check_context_manager.py
@@ -41,7 +41,7 @@ def test_context_manager_fail(testdir):
     ])
 
 
-def test_context_manager_with_msg(testdir):
+def test_context_manager_fail_with_msg(testdir):
     testdir.makepyfile(
         """
         from pytest_check import check

--- a/tests/test_check_context_manager.py
+++ b/tests/test_check_context_manager.py
@@ -81,3 +81,22 @@ def test_stop_on_fail(testdir):
     result.stdout.fnmatch_lines([
         "*assert 1 == 0*",
     ])
+
+
+def test_stop_on_fail_with_msg(testdir):
+    testdir.makepyfile(
+        """
+        from pytest_check import check
+
+        def test_failures():
+            with check("first fail"): assert 1 == 0
+            with check("second fail"): assert 1 > 2
+            with check("third fail"): assert 1 < 5 < 4
+    """
+    )
+
+    result = testdir.runpytest('-x')
+    result.assert_outcomes(failed=1, passed=0)
+    result.stdout.fnmatch_lines([
+        "*first fail*",
+    ])


### PR DESCRIPTION
This adds a msg attribute to CheckContextManager. This is set to None by default, but can be changed by calling `check`. If set, failures inside the `check` context are logged with this message, instead of simply the assertion error.

This is useful if multiple checks all test for roughly the same thing, and you want to log them all in the same context, e.g.:

`test_a_class.py`
```python
from dataclasses import dataclass
from pytest_check import check

@dataclass
class A:
    name: str = ""
    value: float = 1

def test_class_a():
    with check("test default parameters of A"):
        a = A()
        assert a.name == ""
        assert a.value == 0

```

This now gets logged as:

```
=================================== FAILURES ===================================
________________________________ test_failures _________________________________
FAILURE: test default parameters of A
test_a_class.py:13 in test_failures() -> assert a.value == 0

```