### PR TITLE
Increase coverage to 100% with tests against multiple pytest versions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,9 @@ jobs:
       py37:
         TOXENV: py37
         py: '3.7'
+      py38:
+        TOXENV: py38
+        py: '3.8'
       flake8:
         TOXENV: flake8
         py: '3.7'

--- a/src/pytest_check/__init__.py
+++ b/src/pytest_check/__init__.py
@@ -1,9 +1,7 @@
 """A pytest plugin that allows multiple failures per test."""
 import pytest
-
-pytest.register_assert_rewrite("pytest_check.check")
-
 from pytest_check.check_methods import *  # noqa: F401, F402, F403
 
+pytest.register_assert_rewrite("pytest_check.check")
 
 __version__ = "0.3.8"

--- a/src/pytest_check/__init__.py
+++ b/src/pytest_check/__init__.py
@@ -4,4 +4,4 @@ from pytest_check.check_methods import *  # noqa: F401, F402, F403
 
 pytest.register_assert_rewrite("pytest_check.check")
 
-__version__ = "0.3.8"
+__version__ = "0.3.9"

--- a/src/pytest_check/check_methods.py
+++ b/src/pytest_check/check_methods.py
@@ -22,8 +22,7 @@ __all__ = [
     "greater_equal",
     "less",
     "less_equal",
-    "check_func",
-    "raises"
+    "check_func"
 ]
 
 
@@ -177,37 +176,6 @@ def less(a, b, msg=""):
 @check_func
 def less_equal(a, b, msg=""):
     assert a <= b, msg
-
-
-def raises(expected_excs, msg=""):
-    return CheckRaisesContext(expected_excs, msg)
-
-
-class CheckRaisesContext:
-    def __init__(self, expected_excs, msg=""):
-        self.expected_excs = expected_excs
-        self.msg = msg
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        __tracebackhide__ = True
-        if exc_type is not None and issubclass(exc_type, self.expected_excs):
-            return True
-        else:
-            try:
-                raise DidNotRaiseException(self.msg)
-            except DidNotRaiseException as e:
-                if _stop_on_fail:
-                    return
-                else:
-                    log_failure(e)
-                    return True
-
-
-class DidNotRaiseException(Exception):
-    pass
 
 
 def get_full_context(level):

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -80,11 +80,6 @@ def test_less_equal():
     check.less_equal(1, 1)
 
 
-def test_raises():
-    with check.raises(AssertionError):
-        assert 0
-
-
 def test_watch_them_all_fail(testdir):
     testdir.makepyfile(
         """

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,13 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
 envlist =
+          cov_clean,
           py27,
           py36,
           py37,
+          py38,
+          py38_pytest5.3,
+          cov_report,
           flake8
 
 skip_missing_interpreters = true
@@ -11,19 +15,35 @@ isolated_build = True
 
 
 [testenv]
-deps = coverage
+deps =
+    coverage
+    pytest
 parallel_show_output=true
 commands =
-    coverage erase
-    coverage run --source={envsitepackagesdir}/pytest_check -m pytest tests
-    coverage report
+    coverage run --parallel --source={envsitepackagesdir}/pytest_check,tests -m pytest tests
 description = Run pytest, with coverage
 
+[testenv:py38_pytest5.3]
+deps =
+    coverage
+    pytest==5.3.5
+parallel_show_output=true
+description = run with an old pytest
+
+[testenv:cov_clean]
+commands = coverage erase
+description = Remove coverage data
+
+[testenv:cov_report]
+commands =
+    coverage combine
+    coverage report
+description = Report coverage data
 
 [testenv:flake8]
 skip_install = true
 deps = flake8
-basepython = python3.7
+basepython = python3.8
 commands = python -m flake8 src tests
 description = Run flake8 over src, tests
 
@@ -32,6 +52,7 @@ python =
     2.7: py27
     3.6: py36
     3.7: py37
+    3.8: py38
 
 [testenv:cov]
 whitelist_externals=/usr/bin/open
@@ -63,3 +84,8 @@ commands =
     flit build
     twine upload -r pypi dist/*
     rm -rf build/ dist/
+
+[pytest]
+; there's an annoying DepricationWarning that crept into pytest 5.4.1 
+; this line suppresses all warnings, not great, but there we have it.
+addopts = -p no:warnings


### PR DESCRIPTION
- revert PR 35, check.raises, due to incomplete test coverage
- increase coverage to 100% code & branch
- add py38 testing
- add testing of pytest 5.3, since the 5.4 behavior change caused conditional code
- change tox.ini to combine coverage over multiple test runs
- a flake8 fix