### PR TITLE
Copy the failures on node's item

### DIFF
--- a/src/pytest_check/plugin.py
+++ b/src/pytest_check/plugin.py
@@ -28,6 +28,8 @@ def pytest_runtest_makereport(item, call):
         evalxfail = getattr(item, "_evalxfail", None)
 
     failures = check_methods.get_failures()
+    # clones failures to request's node item
+    item.failures = failures[:]
     check_methods.clear_failures()
 
     if failures:


### PR DESCRIPTION
saves failures on requests nodes item so that its available for any further processing