### PR TITLE
Add excinfo to `call` object if an exception has occurred

### DIFF
--- a/src/pytest_check/plugin.py
+++ b/src/pytest_check/plugin.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import pytest
+from _pytest._code.code import ExceptionInfo
 from . import check_methods
 
 # This is ugly.
@@ -34,6 +35,12 @@ def pytest_runtest_makereport(item, call):
             else:
                 report.longrepr = "\n".join(longrepr)
             report.outcome = "failed"
+            try:
+                raise AssertionError(report.longrepr)
+            except AssertionError:
+                excinfo = ExceptionInfo.from_current()
+            call.excinfo = excinfo
+
 
 
 def pytest_configure(config):

--- a/src/pytest_check/plugin.py
+++ b/src/pytest_check/plugin.py
@@ -42,7 +42,6 @@ def pytest_runtest_makereport(item, call):
             call.excinfo = excinfo
 
 
-
 def pytest_configure(config):
     check_methods.set_stop_on_fail(config.getoption("-x"))
 


### PR DESCRIPTION
Try to fix #57. Also link to https://github.com/allure-framework/allure-python/issues/376
Now allure normally received exception info
![image](https://user-images.githubusercontent.com/31664571/128294340-e1250358-64be-4a82-8234-cc61d1d6bd60.png)

Maybe need some small formatting changes and tests
@okken How can we test it? Add integration test with `allure-pytest` installation?