### PR TITLE
Attempt 2: Add check raises with test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ venv/
 README.html
 build/
 htmlcov/
+*.swp

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ def test_example(check):
 - **check.greater_equal** - *a >= b*
 - **check.less** - *a < b*
 - **check.less_equal** - *a <= b*
+- **check.raises** - *func raises given exception* similar to [pytest.raises](https://docs.pytest.org/en/latest/reference/reference.html#pytest-raises)
 
 ## Defining your own check functions
 
@@ -163,6 +164,23 @@ so you will need to use multiple `with check:` blocks for multiple asserts:
         with check: assert 1 < 5 < 4
 
 ```
+
+## Using raises as a context manager
+
+`raises` can also be used as a context manager:
+
+```python
+from pytest_check import raises
+
+
+def test_context_manager():
+    with raises(AssertionError):
+        x = 3
+        assert 1 < x < 4
+```
+
+Just like with `check` as a context manager, execution won't proceed past the first line that throws an error, even if it is successfully captured and logged by Pytest Check.
+Break your assertions over multiple uses of `raises` if you encounter this problem.
 
 ## maxfail behavior
 

--- a/src/pytest_check/__init__.py
+++ b/src/pytest_check/__init__.py
@@ -4,4 +4,4 @@ from pytest_check.check_methods import *  # noqa: F401, F402, F403
 
 pytest.register_assert_rewrite("pytest_check.check")
 
-__version__ = "1.0.4"
+__version__ = "1.0.5"

--- a/src/pytest_check/check_methods.py
+++ b/src/pytest_check/check_methods.py
@@ -190,8 +190,62 @@ def less_equal(a, b, msg=""):
     assert a <= b, msg
 
 
-def raises(*args, **kwargs):
-    return CheckRaisesContext(*args, **kwargs)
+def raises(expected_exception, *args, **kwargs):
+    """
+    Check that a given callable or context raises an error of a given type.
+
+    Can be used as either a context manager:
+
+    >>> with raises(AssertionError):
+    >>>     raise AssertionError
+
+    or as a function:
+
+    >>> def raises_assert():
+    >>>     raise AssertionError
+    >>> raises(AssertionError, raises_assert)
+
+    `expected_exception` follows the same format rules as the second argument
+    to `issubclass`, so multiple possible exception types can be used.
+
+    When args[0] is callable, the remainder of args and all of kwargs except
+    for any called `msg` are passed to args[0] as arguments.
+
+    Note that because `raises` is implemented using a context manager, the
+    usual control flow warnings apply: within the context, execution stops on
+    the first error encountered *and does not resume after this error has been
+    logged*.  Therefore, the line you expect to raise an error must be the last
+    line of the context: any subsequent lines won't be executed.  Pull such
+    lines out of the context if they don't raise errors, or use more calls to
+    `raises` if they do.
+
+    This function is modeled loosely after Pytest's own `raises`, except for
+    the latter's `match`-ing logic.  We should strive to keep the call
+    signature of this `raises` as close as possible to the other `raises`.
+    """
+    __tracebackhide__ = True
+
+    if isinstance(expected_exception, type):
+        excepted_exceptions = (expected_exception,)
+    else:
+        excepted_exceptions = expected_exception
+
+    assert all(
+        isinstance(exc, type) or issubclass(exc, BaseException)
+        for exc in excepted_exceptions
+    )
+
+    msg = kwargs.pop("msg", None)
+    if not args:
+        assert not kwargs, (
+            f"Unexpected kwargs for pytest_check.raises: {kwargs}"
+        )
+        return CheckRaisesContext(expected_exception, msg=msg)
+    else:
+        func = args[0]
+        assert callable(func)
+        with CheckRaisesContext(expected_exception, msg=msg):
+            func(*args[1:], **kwargs)
 
 
 class CheckRaisesContext:
@@ -215,38 +269,28 @@ class CheckRaisesContext:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         __tracebackhide__ = True
-        # FIXME: DeMorgan-ize this.
         if exc_type is not None and issubclass(exc_type, self.expected_excs):
-            self.msg = None
+            # This is the case where an error has occured within the context
+            # but it is the type we're expecting.  Therefore we return True
+            # to silence this error and proceed with execution outside the
+            # context.
             return True
-        else:
-            # FIXME: why not `if not _stop_on_fail` and no return?
-            if _stop_on_fail:
-                # Returning something falsey here will cause the context
-                # manager to *not* suppress an exception not in
-                # `expected_excs`, thus allowing the higher-level Pytest
-                # context to handle it like any other unhandle exception during
-                # test execution, including display and tracebacks.
-                self.msg = None
-                return
-            else:
-                # FIXME: use `or` statement for `log_failure` to shorten
-                if self.msg is not None:
-                    log_failure(self.msg)
-                else:
-                    log_failure(exc_val)
-                self.msg = None
-                return True
-
-    def __call__(self, callable_, *args, msg=None, **kwargs):
-        self.msg = msg
-        callable_(*args, **kwargs)
-
-        return self
 
 
 class DidNotRaiseException(Exception):
     pass
+        if not _stop_on_fail:
+            # Returning something falsey here will cause the context
+            # manager to *not* suppress an exception not in
+            # `expected_excs`, thus allowing the higher-level Pytest
+            # context to handle it like any other unhandle exception during
+            # test execution, including display and tracebacks.  That is the
+            # behavior we want when `_stop_on_fail` is True, so we let that
+            # case fall through.  If *not* `_stop_on_fail`, then we want to
+            # log the error as a failed check but then continue execution
+            # without raising an error, hence `return True`.
+            log_failure(self.msg if self.msg else exc_val)
+            return True
 
 
 def get_full_context(level):

--- a/src/pytest_check/check_methods.py
+++ b/src/pytest_check/check_methods.py
@@ -250,14 +250,12 @@ def raises(expected_exception, *args, **kwargs):
 
 class CheckRaisesContext:
     """
-    TODO: docstring
+    Helper context for `raises` that can be parameterized by error type.
 
-    Within this context or when using as a called method, CheckRaisesContext
-    will only catch one error, the first one, and return it.  It cannot resume
-    control flow after an exception in the code being tested and accumulate
-    other errors.  Use multiple calls to `raises` on subsections of that code
-    that raise only one error apiece if you'd like to accomplish something like
-    that.
+    Note that CheckRaisesContext is instantiated whenever needed; it is not a
+    global variable like `check`.  Therefore, we don't need to curate
+    `self.msg` in `__exit__` for this class like we do with
+    CheckContextManager.
     """
 
     def __init__(self, *expected_excs, msg=None):
@@ -276,9 +274,6 @@ class CheckRaisesContext:
             # context.
             return True
 
-
-class DidNotRaiseException(Exception):
-    pass
         if not _stop_on_fail:
             # Returning something falsey here will cause the context
             # manager to *not* suppress an exception not in
@@ -301,17 +296,6 @@ def get_full_context(level):
 
 
 def log_failure(msg):
-    """
-    Add a fail notice and "pseudo-traceback" to the global list of failures
-
-    A pseudo-traceback looks like a traceback and is constructed similarly to
-    one, but it only references client code, not library code.  We don't have
-    full access to Pytest's traceback machinery here.
-    """
-
-    # TODO: Do I need this?  Could I rewrite to use `traceback` library, since
-    # catching exceptions will give me a traceback object?
-
     __tracebackhide__ = True
     level = 3
     pseudo_trace = []

--- a/tests/test_check_raises.py
+++ b/tests/test_check_raises.py
@@ -1,0 +1,184 @@
+import pytest
+
+from pytest_check import raises
+
+
+class BaseTestException(Exception):
+    pass
+
+
+class TestException(BaseTestException):
+    __test__ = False
+
+
+class AnotherTestException(BaseTestException):
+    pass
+
+
+def test_raises():
+    with raises(TestException):
+        raise TestException
+
+
+def test_raises_with_assertion_error():
+    with raises(AssertionError):
+        assert 0
+
+
+def test_raises_with_multiple_errors(testdir):
+    with raises(TestException, AnotherTestException):
+        raise TestException
+
+    with raises(TestException, AnotherTestException):
+        raise AnotherTestException
+
+    testdir.makepyfile(
+        """
+        from pytest_check import raises
+
+        class BaseTestException(Exception):
+            pass
+
+
+        class TestException(BaseTestException):
+            __test__ = False
+
+
+        class AnotherTestException(BaseTestException):
+            pass
+
+        def test_failures():
+            with raises(TestException, AnotherTestException):
+                raise AssertionError
+    """
+    )
+
+    result = testdir.runpytest()
+    result.assert_outcomes(failed=1, passed=0)
+    result.stdout.fnmatch_lines(
+        ["*FAILURE: ", "*raise AssertionError*"], consecutive=True,
+    )
+
+
+def test_raises_with_parents_and_children(testdir):
+    with raises(BaseTestException):
+        raise TestException
+
+    with raises(BaseTestException, TestException):
+        raise BaseTestException
+
+    with raises(BaseTestException, TestException):
+        raise TestException
+
+    # Children shouldn't catch their parents, only vice versa.
+    testdir.makepyfile(
+        """
+        from pytest_check import raises
+
+        class BaseTestException(Exception):
+            pass
+
+
+        class TestException(BaseTestException):
+            __test__ = False
+
+
+        class AnotherTestException(BaseTestException):
+            pass
+
+        def test_failures():
+            with raises(TestException, AnotherTestException):
+                raise BaseTestException
+    """
+    )
+
+    result = testdir.runpytest()
+    result.assert_outcomes(failed=1, passed=0)
+    result.stdout.fnmatch_lines(
+        ["*FAILURE: ", "*raise BaseTestException*"], consecutive=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "run_flags,match_lines",
+    [
+        ("--exitfirst", ["test_raises_stop_on_fail.py:15: ValueError"]),
+        ("", ["*Failed Checks: 2*"]),
+    ],
+)
+def test_raises_stop_on_fail(run_flags, match_lines, testdir):
+    """
+    Test multiple failures with and without `--exitfirst`
+
+    With `--exitfirst`, first error is the only one reported, and without,
+    multiple errors are accumulated.
+    """
+    # test_failures below includes one passed check, two checked failures, and
+    # a final passed check.  `--exitfirst` should result in only the first
+    # error reported, and subsequent errors and successes are ignored.  Without
+    # that flag, two failures should be counted and reported, and the last
+    # success should be executed.
+    testdir.makepyfile(
+        """
+        from pytest_check import raises
+
+        class BaseTestException(Exception):
+            pass
+
+
+        class TestException(BaseTestException):
+            __test__ = False
+
+        def test_failures():
+            with raises(BaseTestException):
+                raise BaseTestException
+
+            with raises(BaseTestException):
+                raise ValueError
+
+            with raises(BaseTestException):
+                raise ValueError
+
+            with raises(BaseTestException):
+                raise BaseTestException
+    """
+    )
+
+    result = testdir.runpytest(run_flags)
+    result.assert_outcomes(failed=1)
+    result.stdout.fnmatch_lines(match_lines)
+
+
+def test_can_mix_assertions_and_checks(testdir):
+    """
+    You can mix checks and asserts, but a failing assert stops test execution.
+    """
+    testdir.makepyfile(
+        """
+        import pytest_check as check
+
+        from pytest_check import raises
+
+        def test_failures():
+            assert 0 == 0
+
+            check.equal(1, 1)
+
+            check.equal(0, 1)
+
+            assert 1 == 2
+
+            check.equal(2, 3)
+    """
+    )
+
+    result = testdir.runpytest()
+    result.assert_outcomes(failed=1)
+    # Accumulated check fails are reported up to assert failure, but not after.
+    result.stdout.fnmatch_lines(["*Failed Checks: 1*"])
+    result.stdout.fnmatch_lines(
+        ["*FAILURE: ", "assert 0 == 1"], consecutive=True,
+    )
+
+    # Regular assert errors are reported as usual.
+    result.stdout.fnmatch_lines(["E * assert 1 == 2"])

--- a/tests/test_check_raises.py
+++ b/tests/test_check_raises.py
@@ -55,8 +55,14 @@ def test_raises_with_multiple_errors(testdir):
 
     result = testdir.runpytest()
     result.assert_outcomes(failed=1, passed=0)
-    result.stdout.fnmatch_lines(
-        ["*FAILURE: ", "*raise AssertionError*"], consecutive=True,
+    result.stdout.re_match_lines(
+        [
+            "FAILURE: ",
+            # Python < 3.10 reports error at `raise` but 3.10 reports at `with`
+            r".*raise AssertionError.*"
+            r"|.*with raises\(\(TestException, AnotherTestException\)\):.*",
+        ],
+        consecutive=True,
     )
 
 
@@ -94,8 +100,14 @@ def test_raises_with_parents_and_children(testdir):
 
     result = testdir.runpytest()
     result.assert_outcomes(failed=1, passed=0)
-    result.stdout.fnmatch_lines(
-        ["*FAILURE: ", "*raise BaseTestException*"], consecutive=True,
+    result.stdout.re_match_lines(
+        [
+            "FAILURE: ",
+            # Python < 3.10 reports error at `raise` but 3.10 reports at `with`
+            r".*raise BaseTestException.*"
+            r"|.*with raises\(\(TestException, AnotherTestException\)\):.*",
+        ],
+        consecutive=True,
     )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ commands =
     coverage erase
     coverage run --parallel --source={envsitepackagesdir}/pytest_check,tests -m pytest tests
     coverage combine
-    coverage report
+    coverage report --fail-under=100
 description = Run pytest, with coverage
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ isolated_build = True
 
 [testenv]
 deps = pytest
-commands = pytest tests
+commands = pytest {posargs}
 description = Run pytest
 
 [testenv:coverage]


### PR DESCRIPTION
CC @okken @dillonm197

Retrying https://github.com/okken/pytest-check/pull/35.

Add a new method, `raises`, modeled after `pytest.raises` that checks that an assertion of a given type is raised by a code block.

Love the Python Bytes podcast, by the way, @okken.  I was astounded when I realized you were the same "Okken" as the one whose repo I commented on!

## Background

We've tried to add a `raises` method in both https://github.com/okken/pytest-check/pull/35 and before that https://github.com/okken/pytest-check/pull/33.  However, test coverage was lacking and the submitted version couldn't be used as a function as well as a context manager, which fits some of my use cases.

## What Changed

I added an amended form of `raises` that is modeled off of `pytest.raises` such that they have similar call signatures (i.e. support being used both as a context manager and as a function, as well as supplying a custom `msg` message for each error).

I also made one or two minor environment modifications that I encountered while working in this repo that I think will improve developer satisfaction, and I'll call them out in-line.  Please do check if they work for your setup, @okken, as well as the CI/CD you have for this repo.

## How Tested

I also added an extensive test suite, mostly in a new test file, that tests both successes and failures.  My intention was to explicitly cover @okken's questions here: https://github.com/okken/pytest-check/pull/35#issuecomment-632844298.

## Documentation Updates

I've added entries to the README in the README's style for both the function and context manager style 
