### PR TITLE
Alternative fix proposition for #55 : the abspath is used as fallback…

### DIFF
--- a/src/pytest_check/check_methods.py
+++ b/src/pytest_check/check_methods.py
@@ -290,7 +290,10 @@ class CheckRaisesContext:
 
 def get_full_context(level):
     (_, filename, line, funcname, contextlist) = inspect.stack()[level][0:5]
-    filename = os.path.relpath(filename)
+    try:
+        filename = os.path.relpath(filename)
+    except ValueError:
+        filename = os.path.abspath(filename)
     context = contextlist[0].strip() if contextlist else ""
     return (filename, line, funcname, context)
 


### PR DESCRIPTION
… if the relpath did not work (baase on the exception produced on window with several drives)