### PR TITLE
Allow check.check as a context manager when using check fixture

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,15 @@ All notable changes to this project  be documented in this file.
 
 - nothing so far 
 -->
+## [1.1.3] - 2022-Nov-22
+
+### Fixed
+
+- While using the `check` fixture, allow `check.check` as a context manager.
+  - this is unnecessary, the `check` fixture now works as a context manager.
+  - but apparently some people have been using `with check.check:`
+  - so this fix makes that work.
+
 ## [1.1.2] - 2022-Nov-21
 
 ### Added

--- a/examples/test_example_check_check.py
+++ b/examples/test_example_check_check.py
@@ -1,0 +1,16 @@
+"""
+"with check.check:" - bad
+"with check:" - good
+
+However, we want both to work.
+"""
+
+def test_check(check):
+    with check:
+        assert True
+
+def test_check_check(check):
+    "Deprecated, but should still work for now"
+    with check.check:
+        assert True
+

--- a/examples/test_example_check_check.py
+++ b/examples/test_example_check_check.py
@@ -5,12 +5,13 @@
 However, we want both to work.
 """
 
+
 def test_check(check):
     with check:
         assert True
+
 
 def test_check_check(check):
     "Deprecated, but should still work for now"
     with check.check:
         assert True
-

--- a/src/pytest_check/__init__.py
+++ b/src/pytest_check/__init__.py
@@ -1,5 +1,5 @@
 """A pytest plugin that allows multiple failures per test."""
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 
 import pytest
 
@@ -22,11 +22,16 @@ from pytest_check.context_manager import check  # noqa: F401, F402, F403
 #     assert 0
 from pytest_check.check_raises import raises  # noqa: F401, F402, F403
 
+# make sure assert rewriting happens
+pytest.register_assert_rewrite("pytest_check.check")
+
 # allow check level raises
 setattr(check, "raises", raises)
 
-# make sure assert rewriting happens
-pytest.register_assert_rewrite("pytest_check.check")
+# allow check.check as a context manager.
+# weird, but some people are doing it.
+# decprecate this eventually
+setattr(check, "check", check)
 
 # allow for helper functions to be part of check context
 # manager and check fixture:

--- a/tests/test_check_check.py
+++ b/tests/test_check_check.py
@@ -1,0 +1,4 @@
+def test_check_check(pytester):
+    pytester.copy_example("examples/test_example_check_check.py")
+    result = pytester.runpytest()
+    result.assert_outcomes(failed=0, passed=2)


### PR DESCRIPTION
Make this work:

```python
def test_check_check(check):
    "Deprecated, but should still work for now"
    with check.check:
        assert True
```