### PR TITLE
Add any_failures function to skip further checking if any failure due to a first group of checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A pytest plugin that allows multiple failures per test.
 
 ----
 
-Normally, a test funcion will fail and stop running with the first failed `assert`.
+Normally, a test function will fail and stop running with the first failed `assert`.
 That's totally fine for tons of kinds of software tests.
 However, there are times where you'd like to check more than one thing, and you'd really like to know the results of each check, even if one of them fails.
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A pytest plugin that allows multiple failures per test.
 
 ----
 
-Normally, a test funcion will fail and stop running with the first failed `assert`.  
-That's totally fine for tons of kinds of software tests.  
+Normally, a test funcion will fail and stop running with the first failed `assert`.
+That's totally fine for tons of kinds of software tests.
 However, there are times where you'd like to check more than one thing, and you'd really like to know the results of each check, even if one of them fails.
 
 `pytest-check` allows multiple failed "checks" per test function, so you can see the whole picture of what's going wrong.
@@ -33,11 +33,11 @@ def test_httpx_get():
     assert r.status_code == 200
     # but if we get to here
     # then check everything else without stopping
-    with check: 
+    with check:
         assert r.is_redirect is False
-    with check: 
+    with check:
         assert r.encoding == 'utf-8'
-    with check: 
+    with check:
         assert 'Example Domain' in r.text
 ```
 
@@ -51,14 +51,14 @@ You can also grab `check` as a fixture with no import:
 def test_httpx_get(check):
     r = httpx.get('https://www.example.org/')
     ...
-    with check: 
+    with check:
         assert r.is_redirect == False
     ...
 ```
 
 ## Validation functions
 
-`check` also helper functions for common checks.  
+`check` also helper functions for common checks.
 These methods do NOT need to be inside of a `with check:` block.
 
 - **check.equal** - *a == b*
@@ -131,7 +131,7 @@ def test_raises():
 ## Pseudo-tracebacks
 
 With `check`, tests can have multiple failures per test.
-This would possibly make for extensive output if we include the full traceback for 
+This would possibly make for extensive output if we include the full traceback for
 every failure.
 To make the output a little more concise, `pytest-check` implements a shorter version, which we call pseudo-tracebacks.
 
@@ -187,6 +187,19 @@ Setting `-maxfail=2` or greater will turn off any handling of maxfail within thi
 In other words, the `maxfail` count is counting tests, not checks.
 The exception is the case of `1`, where we want to stop on the very first failed check.
 
+## any_failure()
+Use any_failure in case it has no sense to go on with a second group of checks if any of the first one has failed. E.g:
+
+```python
+from pytest_check import check, any_failures
+
+def test_with_groups_of_checks():
+    check.equal(1, 1)
+    check.equal(2, 3)
+    if not any_failures():
+        check.equal(1, 2)
+        check.equal(2, 2)
+```
 
 ## Contributing
 

--- a/examples/test_example_any_failures.py
+++ b/examples/test_example_any_failures.py
@@ -1,0 +1,28 @@
+"""
+Stop checking if any failure in first block of checks.
+
+It's not worth second block of checks if any failure in the first block
+
+"""
+from pytest_check import check
+from pytest_check import any_failures
+
+
+def test_any_failures_false():
+    check.equal(1, 1)
+    check.equal(2, 2)
+    if not any_failures():
+        check.equal(1, 2)
+        check.equal(1, 3)
+        check.equal(1, 4)
+
+
+def test_any_failures_true():
+    check.equal(1, 1)
+    check.equal(2, 3)
+    if not any_failures():
+        check.equal(1, 2)
+        check.equal(2, 2)
+        check.equal(1, 3)
+        check.equal(1, 4)
+        check.equal(1, 5)

--- a/src/pytest_check/__init__.py
+++ b/src/pytest_check/__init__.py
@@ -22,6 +22,9 @@ from pytest_check.context_manager import check  # noqa: F401, F402, F403
 #     assert 0
 from pytest_check.check_raises import raises  # noqa: F401, F402, F403
 
+# allow to know if any_failures after any precedent block of checks
+from pytest_check.check_log import any_failures  # noqa: F401, F402, F403
+
 # make sure assert rewriting happens
 pytest.register_assert_rewrite("pytest_check.check")
 

--- a/src/pytest_check/__init__.py
+++ b/src/pytest_check/__init__.py
@@ -22,7 +22,7 @@ from pytest_check.context_manager import check  # noqa: F401, F402, F403
 #     assert 0
 from pytest_check.check_raises import raises  # noqa: F401, F402, F403
 
-# allow to know if any_failures after any precedent block of checks
+# allow to know if any_failures due to any previous check
 from pytest_check.check_log import any_failures  # noqa: F401, F402, F403
 
 # make sure assert rewriting happens

--- a/src/pytest_check/check_log.py
+++ b/src/pytest_check/check_log.py
@@ -10,6 +10,10 @@ def clear_failures():
     _failures = []
 
 
+def any_failures() -> bool:
+    return bool(get_failures())
+
+
 def get_failures():
     return _failures
 

--- a/tests/test_any_failures.py
+++ b/tests/test_any_failures.py
@@ -1,0 +1,24 @@
+def test_any_failures_false(pytester):
+    pytester.copy_example("examples/test_example_any_failures.py")
+    result = pytester.runpytest("-k", "test_any_failures_false")
+    result.assert_outcomes(failed=1, passed=0)
+    result.stdout.fnmatch_lines(
+        [
+            "*assert 1 == 2*",
+            "*assert 1 == 3*",
+            "*assert 1 == 4*",
+            "*Failed Checks: 3",
+        ]
+    )
+
+
+def test_any_failure_true(pytester):
+    pytester.copy_example("examples/test_example_any_failures.py")
+    result = pytester.runpytest("-k", "test_any_failures_true")
+    result.assert_outcomes(failed=1, passed=0)
+    result.stdout.fnmatch_lines(
+        [
+            "*assert 2 == 3*",
+            "*Failed Checks: 1",
+        ]
+    )


### PR DESCRIPTION
First of all thanks for this pytest plugin (we started to use it around 6 months ago). And we implemented very soon on our side this any_failures() function to check a container deployment:
* First we have a first group of checks for the init_container, 
* And second we have a second group of checks for the container. So it has no sense to keep running these second checks if any previous init_container check has failed. Also this help to reduce noise when checking results

Due to your recent refactoring, It broke the our customized any_failures, so It decided me to prepare this PR so anyone can also reuse this simple change:
- Including boolean any_failure() function and its import. 
- Adding unitary tests
- And adding a short explanation to readme 
  Note: A typo is also fixed, and some useless spaces removed

Please let me know your feedback (for example if you agree with feature and name), and/or if anything else is needed
