### PR TITLE
DOC: Add conda installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ From PyPI:
 $ pip install pytest-check
 ```
 
+From conda (conda-forge):
+```
+$ conda install -c conda-forge pytest-check
+```
 
 ## Example
 


### PR DESCRIPTION
Some user (me included) use conda to manage their python envs.
I saw that `pytest-check` is available in conda-forge artifact repository: https://github.com/conda-forge/pytest_check-feedstock
but this is not obvious when reading the Readme.

This PR fixes this by adding the instruction on how to install pytest-check from conda-forge.