### PR TITLE
2.0.0 - new --check-max-tb, defaults to 1, deprecate --check-no-tb

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,25 +215,27 @@ def test_with_groups_of_checks():
 If you have lots of check failures, your tests may not run as fast as you want.  
 There are a few ways to speed things up.
 
-* `--check-no-tb` - report reason for failure, but not pseudo-traceback.
+* `--check-max=tb` - Only report this many pseudo-tracebacks per test.
     * pytest-check uses custom traceback code I'm calling a pseudo-traceback. 
     * This is visually shorter than normal assert tracebacks.
     * Internally, it uses introspection, which can be slow.
-    * Turning off pseudo-tracebacks speeds things up quite a bit.
+    * Allowing a limited number of pseudo-tracebacks speeds things up quite a bit.
+    * Default is 1.
 
 * `--check-max-report=10` - limit reported failures per test.
     * The example shows `10` but any number can be used.
     * The test will still have the total nuber of failures reported.
+    * Default is no maximum.
 
 * `--check-max-fail=20` - Stop the test after this many check failures.
     * This is useful if your code under test is slow-ish and you want to bail early.
+    * Default is no maximum.
 
 * Any of these can be used on their own, or combined.
 
 * Recommendation:
-    * Don't worry about this unless you need to.
-    * If you are using check a lot in tight loops with tons of data points, then speed it up significantly with all of these flags:
-        * `--check-no-tb --check-max-report=10 --check-max-fail=20`.
+    * Leave the default, equivelant to `--check-max-tb=1`.
+    * If excessive output is annoying, set `--check-max-report=10` or some tolerable number.
 
 ## Local speedups
 
@@ -244,8 +246,8 @@ Locally, you can set these values per test.
 From `examples/test_example_speedup_funcs.py`:
 
 ```python
-def test_no_tb():
-    check.set_no_tb()
+def test_max_tb():
+    check.set_max_tb()
     for i in range(1, 11):
         check.equal(i, 100)
 

--- a/changelog.md
+++ b/changelog.md
@@ -20,19 +20,49 @@ All notable changes to this project  be documented in this file.
 
 -->
 
-## [Unreleased] - yyyy-mm-dd
+## [2.0.0] - 2022-12-30
 
 ### Added
 
-- nothing so far
+- With the following change, the default is now pretty darn fast, and most people will not need to modify any settings to get most of the speed improvements.
+- `--check-max-tb=<int>` - sets the max number of pseudo-traceback reports per test function.
+  - Default is 1.
+  - After this, error is still reported 
+    - The error reports continue, they just won't have a traceback.
+    - If you set `--check-max-report`, then the reports stop at that number, with or without tracebacks.a
+- `check.set_max_tb(int)` - overrides `--check-max-tb` for the test function it's called from. Value is reset after one test function.
 
-### Fixed
+### Deprecated
 
-- nothing so far
+- `check.set_no_tb` and `--set-no-tb` will be removed in a future release. (probably soon)
+- `check.set_no_tb` is deprecated.
+  - For now, it internally calls `set_max_tb(0)`. See discussion below.
+- `--check-no-tb` is deprecated.
+  - It's also short lived. 
+  - Since `--check-max-tb` is more useful, the default for `--check-max-tb` is 1, which is already pretty fast.
+    And `--check-max-tb=0` has the same effect as `--check-no-tb`.
 
 ### Changed
 
 - Update README.md with conda install instructions. Thanks @bzah.
+
+### Reason for major version bump
+
+The default behavior has changed. Since `--check-max-tb=1` is the default, the default behavior is now:
+
+- Show traceback for the first failure per test. (controlled by `--check-max-tb`, default is 1)
+- Show error report for the remaining failures in a test. (controlled by `--check-max-report`, default is None)
+
+Old default behavior was the same except all tracebacks would be reported.
+
+My logic here:
+
+- The actual error message, like `check 1 == 3`, is more useful than the traceback.
+- The first traceback is still useful to point you to the test file, line number, of first failure.
+- Other failures are probably close by. 
+
+If this logic doesn't hold for you, you can always set `--check-max-tb=1000` or some other large number.
+
 
 ## [1.3.0] - 2022-Dec-2
 

--- a/changelog.md
+++ b/changelog.md
@@ -20,7 +20,7 @@ All notable changes to this project  be documented in this file.
 
 -->
 
-## [2.0.0] - 2022-12-30
+## [2.0.0b1] - 2022-12-31
 
 ### Added
 

--- a/examples/test_example_speedup_funcs.py
+++ b/examples/test_example_speedup_funcs.py
@@ -6,12 +6,6 @@ def test_baseline():
         check.equal(i, 100)
 
 
-def test_no_tb():
-    check.set_no_tb()
-    for i in range(1, 11):
-        check.equal(i, 100)
-
-
 def test_max_report():
     check.set_max_report(5)
     for i in range(1, 11):
@@ -20,5 +14,11 @@ def test_max_report():
 
 def test_max_fail():
     check.set_max_fail(5)
+    for i in range(1, 11):
+        check.equal(i, 100)
+
+
+def test_max_tb():
+    check.set_max_tb(2)
     for i in range(1, 11):
         check.equal(i, 100)

--- a/src/pytest_check/__init__.py
+++ b/src/pytest_check/__init__.py
@@ -1,5 +1,5 @@
 """A pytest plugin that allows multiple failures per test."""
-__version__ = "1.3.0"
+__version__ = "2.0.0"
 
 import pytest
 

--- a/src/pytest_check/__init__.py
+++ b/src/pytest_check/__init__.py
@@ -1,5 +1,5 @@
 """A pytest plugin that allows multiple failures per test."""
-__version__ = "2.0.0"
+__version__ = "2.0.0b1"
 
 import pytest
 

--- a/src/pytest_check/check_log.py
+++ b/src/pytest_check/check_log.py
@@ -9,21 +9,25 @@ _stop_on_fail = False
 _default_no_tb = False
 _default_max_fail = None
 _default_max_report = None
+_default_max_tb = None
 
 _no_tb = False
 _max_fail = None
 _max_report = None
+_max_tb = None
 _num_failures = 0
 
 
 def clear_failures():
     # get's called at the beginning of each test function
-    global _failures, _num_failures, _no_tb, _max_fail, _max_report
+    global _failures, _num_failures, _no_tb
+    global _max_fail, _max_report, _max_tb
     _failures = []
     _num_failures = 0
     _no_tb = _default_no_tb
     _max_fail = _default_max_fail
     _max_report = _default_max_report
+    _max_tb = _default_max_tb
 
 
 def any_failures() -> bool:
@@ -36,6 +40,7 @@ def get_failures():
 
 def log_failure(msg="", check_str=""):
     global _num_failures
+    global _no_tb
     __tracebackhide__ = True
     _num_failures += 1
 
@@ -45,9 +50,12 @@ def log_failure(msg="", check_str=""):
         msg = f"{msg}: {check_str}"
 
     if (_max_report is None) or (_num_failures <= _max_report):
-        if not _no_tb:
+        if (not _no_tb) and (_num_failures <= _max_tb):
             pseudo_trace_str = _build_pseudo_trace_str()
             msg = f"{msg}\n{pseudo_trace_str}"
+            if _num_failures == _max_tb:
+                _no_tb = True
+
 
         if should_use_color:
             msg = f"{COLOR_RED}{msg}{COLOR_RESET}"

--- a/src/pytest_check/check_log.py
+++ b/src/pytest_check/check_log.py
@@ -6,12 +6,10 @@ COLOR_RESET = "\x1b[0m"
 _failures = []
 _stop_on_fail = False
 
-_default_no_tb = False
 _default_max_fail = None
 _default_max_report = None
 _default_max_tb = None
 
-_no_tb = False
 _max_fail = None
 _max_report = None
 _max_tb = None
@@ -20,11 +18,10 @@ _num_failures = 0
 
 def clear_failures():
     # get's called at the beginning of each test function
-    global _failures, _num_failures, _no_tb
+    global _failures, _num_failures
     global _max_fail, _max_report, _max_tb
     _failures = []
     _num_failures = 0
-    _no_tb = _default_no_tb
     _max_fail = _default_max_fail
     _max_report = _default_max_report
     _max_tb = _default_max_tb
@@ -40,7 +37,6 @@ def get_failures():
 
 def log_failure(msg="", check_str=""):
     global _num_failures
-    global _no_tb
     __tracebackhide__ = True
     _num_failures += 1
 
@@ -50,12 +46,9 @@ def log_failure(msg="", check_str=""):
         msg = f"{msg}: {check_str}"
 
     if (_max_report is None) or (_num_failures <= _max_report):
-        if (not _no_tb) and (_num_failures <= _max_tb):
+        if _num_failures <= _max_tb:
             pseudo_trace_str = _build_pseudo_trace_str()
             msg = f"{msg}\n{pseudo_trace_str}"
-            if _num_failures == _max_tb:
-                _no_tb = True
-
 
         if should_use_color:
             msg = f"{COLOR_RED}{msg}{COLOR_RESET}"

--- a/src/pytest_check/context_manager.py
+++ b/src/pytest_check/context_manager.py
@@ -1,3 +1,4 @@
+import warnings
 from . import check_log
 from .check_log import log_failure
 
@@ -36,14 +37,17 @@ class CheckContextManager:
         return self
 
     def set_no_tb(self):
-        check_log._no_tb = True
+        warnings.warn(
+            "set_no_tb() is deprecated; use set_max_tb(0)", DeprecationWarning
+            )
+        check_log._max_tb = 0
 
     def set_max_fail(self, x):
         check_log._max_fail = x
 
     def set_max_report(self, x):
         check_log._max_report = x
-    
+
     def set_max_tb(self, x):
         check_log._max_tb = x
 

--- a/src/pytest_check/context_manager.py
+++ b/src/pytest_check/context_manager.py
@@ -43,6 +43,9 @@ class CheckContextManager:
 
     def set_max_report(self, x):
         check_log._max_report = x
+    
+    def set_max_tb(self, x):
+        check_log._max_tb = x
 
 
 check = CheckContextManager()

--- a/src/pytest_check/plugin.py
+++ b/src/pytest_check/plugin.py
@@ -65,6 +65,7 @@ def pytest_configure(config):
     check_log._default_no_tb = config.getoption("--check-no-tb")
     check_log._default_max_fail = config.getoption("--check-max-fail")
     check_log._default_max_report = config.getoption("--check-max-report")
+    check_log._default_max_tb = config.getoption("--check-max-tb")
 
 
 # Allow for tests to grab "check" via fixture:
@@ -93,4 +94,11 @@ def pytest_addoption(parser):
         action="store",
         type=int,
         help="max failures per test",
+    )
+    parser.addoption(
+        "--check-max-tb",
+        action="store",
+        type=int,
+        default=1,
+        help="max pseudo-tracebacks per test",
     )

--- a/src/pytest_check/plugin.py
+++ b/src/pytest_check/plugin.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 
 import pytest
 from _pytest._code.code import ExceptionInfo
@@ -62,10 +63,15 @@ def pytest_configure(config):
     pseudo_traceback._traceback_style = traceback_style
 
     # grab options
-    check_log._default_no_tb = config.getoption("--check-no-tb")
     check_log._default_max_fail = config.getoption("--check-max-fail")
     check_log._default_max_report = config.getoption("--check-max-report")
     check_log._default_max_tb = config.getoption("--check-max-tb")
+    no_tb = config.getoption("--check-no-tb")
+    if no_tb:
+        warnings.warn(
+            "--check-no-tb is deprecated; use --check-max-tb=0", DeprecationWarning
+        )
+        check_log._default_max_tb = 0
 
 
 # Allow for tests to grab "check" via fixture:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -10,7 +10,7 @@ def test_sequence_with_helper_funcs(pytester):
     Should show a sequence of calls
     """
     pytester.copy_example("examples/test_example_helpers.py")
-    result = pytester.runpytest()
+    result = pytester.runpytest("--check-max-tb=2")
     result.assert_outcomes(failed=1, passed=0)
     result.stdout.fnmatch_lines(
         [
@@ -32,7 +32,7 @@ def test_sequence_with_helper_funcs_less_checking(pytester):
     Should show a sequence of calls
     """
     pytester.copy_example("examples/test_example_helpers.py")
-    result = pytester.runpytest()
+    result = pytester.runpytest("--check-max-tb=2")
     result.assert_outcomes(failed=1, passed=0)
     result.stdout.fnmatch_lines(
         [

--- a/tests/test_speedup_flags.py
+++ b/tests/test_speedup_flags.py
@@ -1,6 +1,6 @@
 def test_baseline(pytester):
     pytester.copy_example("examples/test_example_multiple_failures.py")
-    result = pytester.runpytest()
+    result = pytester.runpytest("--check-max-tb=10")
     result.assert_outcomes(failed=1)
     result.stdout.fnmatch_lines(
         [
@@ -63,3 +63,11 @@ def test_max_fail(pytester):
         ],
     )
     result.stdout.no_fnmatch_line("*FAILURE: * 6 == 100")
+
+
+def test_max_tb(pytester):
+    pytester.copy_example("examples/test_example_multiple_failures.py")
+    result = pytester.runpytest("--check-max-tb=2")
+    result.assert_outcomes(failed=1)
+    num_tb = str(result.stdout).count("test_multiple_failures() -> check.equal(i, 100)")
+    assert num_tb == 2

--- a/tests/test_speedup_functions.py
+++ b/tests/test_speedup_functions.py
@@ -1,6 +1,9 @@
+import pytest
+
+
 def test_baseline(pytester):
     pytester.copy_example("examples/test_example_speedup_funcs.py")
-    result = pytester.runpytest("-k baseline")
+    result = pytester.runpytest("-k baseline", "--check-max-tb=10")
     result.assert_outcomes(failed=1)
     result.stdout.fnmatch_lines(
         [
@@ -13,21 +16,6 @@ def test_baseline(pytester):
             "Failed Checks: 10",
         ],
     )
-
-
-def test_no_tb(pytester):
-    pytester.copy_example("examples/test_example_speedup_funcs.py")
-    result = pytester.runpytest("-k no_tb")
-    result.assert_outcomes(failed=1)
-    result.stdout.fnmatch_lines(
-        [
-            "*FAILURE: * 7 == 100",
-            "*FAILURE: * 8 == 100",
-            "*FAILURE: * 9 == 100",
-            "Failed Checks: 10",
-        ],
-    )
-    result.stdout.no_fnmatch_line("*test_baseline() -> check.equal(i, 100)")
 
 
 def test_max_report(pytester):
@@ -63,3 +51,39 @@ def test_max_fail(pytester):
         ],
     )
     result.stdout.no_fnmatch_line("*FAILURE: * 6 == 100")
+
+
+def test_max_tb(pytester):
+    pytester.copy_example("examples/test_example_speedup_funcs.py")
+    result = pytester.runpytest("-k max_tb")
+    result.assert_outcomes(failed=1)
+    num_tb = str(result.stdout).count("in test_max_tb() -> check.equal(i, 100)")
+    assert num_tb == 2
+
+
+def test_deprecated_no_tb(check):
+    with pytest.deprecated_call():
+        check.set_no_tb()
+
+
+text_for_test_no_tb = """
+def test_no_tb(check):
+    check.set_no_tb()
+    for i in range(1, 11):
+        check.equal(i, 100)
+"""
+
+
+def test_no_tb(pytester):
+    pytester.makepyfile(text_for_test_no_tb)
+    result = pytester.runpytest("-k no_tb")
+    result.assert_outcomes(failed=1)
+    result.stdout.fnmatch_lines(
+        [
+            "*FAILURE: * 7 == 100",
+            "*FAILURE: * 8 == 100",
+            "*FAILURE: * 9 == 100",
+            "Failed Checks: 10",
+        ],
+    )
+    result.stdout.no_fnmatch_line("*test_baseline() -> check.equal(i, 100)")


### PR DESCRIPTION
The default behavior has changed. Since `--check-max-tb=1` is the default, the default behavior is now:

- Show traceback for the first failure per test. (controlled by `--check-max-tb`, default is 1)
- Show error report for the remaining failures in a test. (controlled by `--check-max-report`, default is None)

Old default behavior was the same except all tracebacks would be reported.

My logic here:

- The actual error message, like `check 1 == 3`, is more useful than the traceback.
- The first traceback is still useful to point you to the test file, line number, of first failure.
- Other failures are probably close by. 

If this logic doesn't hold for you, you can always set `--check-max-tb=1000` or some other large number.