### PR TITLE
Add option for logging every individual failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ def test_httpx_get(check):
 
 ## Validation functions
 
-`check` also helper functions for common checks. 
+`check` also helper functions for common checks.
 These methods do NOT need to be inside of a `with check:` block.
 
 - **check.equal** - *a == b*
@@ -183,6 +183,11 @@ The failures will also be red, unless you turn that off with pytests `--color=no
 
 You can turn off the failure reports with pytests `--tb=no`.
 
+## Logging
+With `--logging-level=<LEVEL>` option, every individual failure is also logged as they appear, so it can be related with the rest of your logging.
+Valid levels are: CRITICAL, ERROR, WARNING, INFO, DEBUG (note: Any other <LEVEL> disables this option)
+
+
 ## Stop on Fail (maxfail behavior)
 
 Setting `-x` or `--maxfail=1` will cause this plugin to abort testing after the first failed check.
@@ -194,7 +199,7 @@ The exception is the case of `1`, where we want to stop on the very first failed
 
 ## any_failures()
 
-Use `any_failures()` to see if there are any failures.  
+Use `any_failures()` to see if there are any failures.
 One use case is to make a block of checks conditional on not failing in a previous set of checks:
 
 ```python
@@ -212,11 +217,11 @@ def test_with_groups_of_checks():
 
 ## Speedups
 
-If you have lots of check failures, your tests may not run as fast as you want.  
+If you have lots of check failures, your tests may not run as fast as you want.
 There are a few ways to speed things up.
 
 * `--check-no-tb` - report reason for failure, but not pseudo-traceback.
-    * pytest-check uses custom traceback code I'm calling a pseudo-traceback. 
+    * pytest-check uses custom traceback code I'm calling a pseudo-traceback.
     * This is visually shorter than normal assert tracebacks.
     * Internally, it uses introspection, which can be slow.
     * Turning off pseudo-tracebacks speeds things up quite a bit.
@@ -237,7 +242,7 @@ There are a few ways to speed things up.
 
 ## Local speedups
 
-The flags above are global settings, and apply to every test in the test run.  
+The flags above are global settings, and apply to every test in the test run.
 
 Locally, you can set these values per test.
 

--- a/examples/test_example_logging.py
+++ b/examples/test_example_logging.py
@@ -1,5 +1,5 @@
 """
-A test file with both `check` and `assert`, both failing
+A test file to try with without logging-level option
 """
 from pytest_check import check
 import logging
@@ -12,8 +12,6 @@ def test_error_level(caplog):
     check.equal("one", "xxx")
     log.warning("Second check")
     check.equal("two", "yyy")
-
-    print(caplog.record_tuples)
 
     assert len(caplog.record_tuples) == 4
 
@@ -37,8 +35,6 @@ def test_no_level(caplog):
     check.equal("one", "xxx")
     log.warning("Second check")
     check.equal("two", "yyy")
-
-    print(caplog.record_tuples)
 
     assert len(caplog.record_tuples) == 2
 

--- a/examples/test_example_logging.py
+++ b/examples/test_example_logging.py
@@ -1,0 +1,49 @@
+"""
+A test file with both `check` and `assert`, both failing
+"""
+from pytest_check import check
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def test_logging_error_level(caplog):
+    log.warning("First check")
+    check.equal("one", "xxx")
+    log.warning("Second check")
+    check.equal("two", "yyy")
+
+    assert len(caplog.record_tuples) == 4
+    assert caplog.record_tuples[0] == (
+        'test_example_logging', logging.WARNING, 'First check'
+    )
+    assert caplog.record_tuples[1] == (
+        'pytest_check.check_log',
+        logging.ERROR,
+        'FAILURE: check one == xxx\ntest_example_logging.py:12 '
+        'in test_logging_error_level() -> check.equal("one", "xxx")\n'
+    )
+    assert caplog.record_tuples[2] == (
+        'test_example_logging', logging.WARNING, 'Second check'
+    )
+    assert caplog.record_tuples[3] == (
+        'pytest_check.check_log',
+        logging.ERROR,
+        'FAILURE: check two == yyy\ntest_example_logging.py:14 '
+        'in test_logging_error_level() -> check.equal("two", "yyy")\n'
+    )
+
+
+def test_logging_no_level(caplog):
+    log.warning("First check")
+    check.equal("one", "xxx")
+    log.warning("Second check")
+    check.equal("two", "yyy")
+
+    assert len(caplog.record_tuples) == 2
+    assert caplog.record_tuples[0] == (
+        'test_example_logging', logging.WARNING, 'First check'
+    )
+    assert caplog.record_tuples[1] == (
+        'test_example_logging', logging.WARNING, 'Second check'
+    )

--- a/examples/test_example_logging.py
+++ b/examples/test_example_logging.py
@@ -7,43 +7,43 @@ import logging
 log = logging.getLogger(__name__)
 
 
-def test_logging_error_level(caplog):
+def test_error_level(caplog):
     log.warning("First check")
     check.equal("one", "xxx")
     log.warning("Second check")
     check.equal("two", "yyy")
+
+    print(caplog.record_tuples)
 
     assert len(caplog.record_tuples) == 4
-    assert caplog.record_tuples[0] == (
-        'test_example_logging', logging.WARNING, 'First check'
-    )
-    assert caplog.record_tuples[1] == (
-        'pytest_check.check_log',
-        logging.ERROR,
-        'FAILURE: check one == xxx\ntest_example_logging.py:12 '
-        'in test_logging_error_level() -> check.equal("one", "xxx")\n'
-    )
-    assert caplog.record_tuples[2] == (
-        'test_example_logging', logging.WARNING, 'Second check'
-    )
-    assert caplog.record_tuples[3] == (
-        'pytest_check.check_log',
-        logging.ERROR,
-        'FAILURE: check two == yyy\ntest_example_logging.py:14 '
-        'in test_logging_error_level() -> check.equal("two", "yyy")\n'
-    )
+
+    message = caplog.record_tuples[0][2]
+    assert message == 'First check'
+
+    _, level, message = caplog.record_tuples[1]
+    assert level == logging.ERROR
+    assert 'FAILURE: check one' in message
+
+    message = caplog.record_tuples[2][2]
+    assert message == 'Second check'
+
+    _, level, message = caplog.record_tuples[3]
+    assert level == logging.ERROR
+    assert 'FAILURE: check two' in message
 
 
-def test_logging_no_level(caplog):
+def test_no_level(caplog):
     log.warning("First check")
     check.equal("one", "xxx")
     log.warning("Second check")
     check.equal("two", "yyy")
 
+    print(caplog.record_tuples)
+
     assert len(caplog.record_tuples) == 2
-    assert caplog.record_tuples[0] == (
-        'test_example_logging', logging.WARNING, 'First check'
-    )
-    assert caplog.record_tuples[1] == (
-        'test_example_logging', logging.WARNING, 'Second check'
-    )
+
+    message = caplog.record_tuples[0][2]
+    assert message == 'First check'
+
+    message = caplog.record_tuples[1][2]
+    assert message == 'Second check'

--- a/src/pytest_check/check_log.py
+++ b/src/pytest_check/check_log.py
@@ -71,6 +71,6 @@ def log_failure(msg="", check_str=""):
 
 
 def log_failure_in_logger(message):
-    level = logging._nameToLevel.get(_logging_level.upper())
+    level = logging._nameToLevel.get(_logging_level)
     if level:
         log.log(level, message)

--- a/src/pytest_check/check_log.py
+++ b/src/pytest_check/check_log.py
@@ -1,4 +1,7 @@
 from .pseudo_traceback import _build_pseudo_trace_str
+import logging
+
+log = logging.getLogger(__name__)
 
 should_use_color = False
 COLOR_RED = "\x1b[31m"
@@ -9,21 +12,24 @@ _stop_on_fail = False
 _default_no_tb = False
 _default_max_fail = None
 _default_max_report = None
+_default_logging_level = ""
 
 _no_tb = False
 _max_fail = None
 _max_report = None
 _num_failures = 0
+_logging_level = ""
 
 
 def clear_failures():
     # get's called at the beginning of each test function
-    global _failures, _num_failures, _no_tb, _max_fail, _max_report
+    global _failures, _num_failures, _no_tb, _max_fail, _max_report, _logging_level
     _failures = []
     _num_failures = 0
     _no_tb = _default_no_tb
     _max_fail = _default_max_fail
     _max_report = _default_max_report
+    _logging_level = _default_logging_level
 
 
 def any_failures() -> bool:
@@ -54,6 +60,7 @@ def log_failure(msg="", check_str=""):
 
         msg = f"FAILURE: {msg}"
         _failures.append(msg)
+        log_failure_in_logger(msg)
 
     if _max_fail and (_num_failures >= _max_fail):
         assert_msg = f"pytest-check max fail of {_num_failures} reached"
@@ -61,3 +68,9 @@ def log_failure(msg="", check_str=""):
 
     if _stop_on_fail:
         assert False, "Stopping on first failure"
+
+
+def log_failure_in_logger(message):
+    level = logging._nameToLevel.get(_logging_level.upper())
+    if level:
+        log.log(level, message)

--- a/src/pytest_check/plugin.py
+++ b/src/pytest_check/plugin.py
@@ -65,6 +65,7 @@ def pytest_configure(config):
     check_log._default_no_tb = config.getoption("--check-no-tb")
     check_log._default_max_fail = config.getoption("--check-max-fail")
     check_log._default_max_report = config.getoption("--check-max-report")
+    check_log._default_logging_level = config.getoption("--logging-level")
 
 
 # Allow for tests to grab "check" via fixture:
@@ -93,4 +94,12 @@ def pytest_addoption(parser):
         action="store",
         type=int,
         help="max failures per test",
+    )
+    parser.addoption(
+        "--logging-level",
+        action="store",
+        type=str,
+        help="level to log any failure (in the moment they are raised): "
+             "FATAL, ERROR, WARNING, INFO, DEBUG "
+             "(Note: Logging is disabled for any other value)",
     )

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,21 +1,21 @@
 
-# def test_logging_level_error(pytester):
-#     """
-#     Should log 2 failures inside log with error level
-#     """
-#     pytester.copy_example("examples/test_example_logging.py")
-#     result = pytester.runpytest(
-#         "--logging-level=ERROR -k test_logging_error_level"
-#     )
-#     result.assert_outcomes(failed=1, passed=0)
-#     result.stdout.fnmatch_lines(["* 2 failed *"])
-#
-#
-# def test_logging_no_level(pytester):
-#     """
-#     Should not log failures
-#     """
-#     pytester.copy_example("examples/test_example_logging.py")
-#     result = pytester.runpytest("-k test_logging_no_level")
-#     result.assert_outcomes(failed=1, passed=0)
-#     result.stdout.fnmatch_lines(["* 2 failed *"])
+def test_logging_level_error(pytester):
+    """
+    Should log 2 failures inside log with error level
+    """
+    pytester.copy_example("examples/test_example_logging.py")
+    result = pytester.runpytest(
+        "--logging-level=ERROR -k test_logging_error_level"
+    )
+    result.assert_outcomes(failed=1, passed=0)
+    result.stdout.fnmatch_lines(["* 2 failed *"])
+
+
+def test_logging_no_level(pytester):
+    """
+    Should not log failures
+    """
+    pytester.copy_example("examples/test_example_logging.py")
+    result = pytester.runpytest("-k test_logging_no_level")
+    result.assert_outcomes(failed=1, passed=0)
+    result.stdout.fnmatch_lines(["* 2 failed *"])

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,21 @@
+
+# def test_logging_level_error(pytester):
+#     """
+#     Should log 2 failures inside log with error level
+#     """
+#     pytester.copy_example("examples/test_example_logging.py")
+#     result = pytester.runpytest(
+#         "--logging-level=ERROR -k test_logging_error_level"
+#     )
+#     result.assert_outcomes(failed=1, passed=0)
+#     result.stdout.fnmatch_lines(["* 2 failed *"])
+#
+#
+# def test_logging_no_level(pytester):
+#     """
+#     Should not log failures
+#     """
+#     pytester.copy_example("examples/test_example_logging.py")
+#     result = pytester.runpytest("-k test_logging_no_level")
+#     result.assert_outcomes(failed=1, passed=0)
+#     result.stdout.fnmatch_lines(["* 2 failed *"])

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,14 +1,14 @@
-
-def test_logging_level_error(pytester):
+def test_logging_error_level(pytester):
     """
     Should log 2 failures inside log with error level
     """
     pytester.copy_example("examples/test_example_logging.py")
     result = pytester.runpytest(
-        "--logging-level=ERROR -k test_logging_error_level"
+        "test_example_logging.py::test_error_level",
+        "--logging-level=ERROR",
     )
     result.assert_outcomes(failed=1, passed=0)
-    result.stdout.fnmatch_lines(["* 2 failed *"])
+    result.stdout.fnmatch_lines(["Failed Checks: 2"])
 
 
 def test_logging_no_level(pytester):
@@ -16,6 +16,6 @@ def test_logging_no_level(pytester):
     Should not log failures
     """
     pytester.copy_example("examples/test_example_logging.py")
-    result = pytester.runpytest("-k test_logging_no_level")
+    result = pytester.runpytest("test_example_logging.py::test_no_level")
     result.assert_outcomes(failed=1, passed=0)
-    result.stdout.fnmatch_lines(["* 2 failed *"])
+    result.stdout.fnmatch_lines(["Failed Checks: 2"])


### PR DESCRIPTION
Thanks again for this plugin. And second PR to this repo :tada: 

Just to add an option to be able to see failures inside log as they appear

Currently you can see all the failures together in the final exception, and so every individual failure can not be related with the rest of your logging.

I have made it optional so behavior is not modified without the option.
And added new unit tests for new code

Please let me know your kind feedback.