### PR TITLE
readd tests and examples to sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,5 @@ build-backend = "flit_core.buildapi"
 [tool.flit.module]
 name = "pytest_check"
 
+[tool.flit.sdist]
+include = ["changelog.md", "examples", "tests", "tox.ini"]


### PR DESCRIPTION
The switch to flit has resulted in examples and tests disappearing from sdist.  Linux distributions need the latter to test the package. Explicitly include all useful files.