### PR TITLE
Fix traceback construction in tests using threadpool

### DIFF
--- a/examples/test_example_fail_in_thread.py
+++ b/examples/test_example_fail_in_thread.py
@@ -1,0 +1,21 @@
+from concurrent.futures.thread import ThreadPoolExecutor
+from threading import Thread
+
+
+import pytest_check as check
+
+
+def force_fail(comparison):
+    check.equal(1 + 1, comparison, f"1 + 1 is 2, not {comparison}")
+
+
+def test_threadpool():
+    with ThreadPoolExecutor() as executor:
+        task = executor.submit(force_fail, 3)
+        task.result()
+
+
+def test_threading():
+    t = Thread(target=force_fail, args=(4, ))
+    t.start()
+    t.join()

--- a/examples/test_example_pass_in_thread.py
+++ b/examples/test_example_pass_in_thread.py
@@ -1,0 +1,21 @@
+from concurrent.futures.thread import ThreadPoolExecutor
+from threading import Thread
+
+
+import pytest_check as check
+
+
+def always_pass():
+    check.equal(1 + 1, 2)
+
+
+def test_threadpool():
+    with ThreadPoolExecutor() as executor:
+        task = executor.submit(always_pass)
+        task.result()
+
+
+def test_threading():
+    t = Thread(target=always_pass)
+    t.start()
+    t.join()

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -1,0 +1,12 @@
+def test_failing_threaded_testcode(pytester):
+    pytester.copy_example("examples/test_example_fail_in_thread.py")
+    result = pytester.runpytest()
+    result.assert_outcomes(failed=2, passed=0)
+    result.stdout.fnmatch_lines(["*1 + 1 is 2, not 3*"])
+    result.stdout.fnmatch_lines(["*1 + 1 is 2, not 4*"])
+
+
+def test_passing_threaded_testcode(pytester):
+    pytester.copy_example("examples/test_example_pass_in_thread.py")
+    result = pytester.runpytest()
+    result.assert_outcomes(failed=0, passed=2)


### PR DESCRIPTION
Fix issue #127 

In a thread, the pseudo-traceback looks like:

```
_________ test_threadpool __________
FAILURE: check 2 == 3: 1 + 1 is 2, not 3
../../../../usr/local/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/lib/python3.11/threading.py:995 in _bootstrap() -> self._bootstrap_inner()
../../../../usr/local/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/lib/python3.11/threading.py:1038 in _bootstrap_inner() -> self.run()
../../../../usr/local/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/lib/python3.11/threading.py:975 in run() -> self._target(*self._args, **self._kwargs)
../../../../usr/local/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/lib/python3.11/concurrent/futures/thread.py:83 in _worker() -> work_item.run()
../../../../usr/local/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/lib/python3.11/concurrent/futures/thread.py:58 in run() -> result = self.fn(*self.args, **self.kwargs)
examples/test_example_fail_in_thread.py:9 in force_fail() -> do_work(comparison)
examples/test_example_fail_in_thread.py:12 in do_work() -> check.equal(1 + 1, comparison, f"1 + 1 is 2, not {comparison}")
```