### PR TITLE
Dev refactoring

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,17 +3,13 @@ name = "pytest-check"
 authors = [{name = "Brian Okken"}]
 readme = "README.md"
 license = {file = "LICENSE.txt"}
+description="A pytest plugin that allows multiple failures per test."
+version = "2.1.4"
 requires-python = ">3.7"
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Intended Audience :: Developers",
-    "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
     "Framework :: Pytest" ,
-    "Topic :: Software Development :: Testing",
 ]
-dynamic = ["version", "description"]
 dependencies = ["pytest"]
 
 [project.urls]

--- a/src/pytest_check/__init__.py
+++ b/src/pytest_check/__init__.py
@@ -1,6 +1,3 @@
-"""A pytest plugin that allows multiple failures per test."""
-__version__ = "2.1.4"
-
 import pytest
 
 # make sure assert rewriting happens

--- a/tox.ini
+++ b/tox.ini
@@ -1,39 +1,34 @@
 [tox]
-envlist =
-          py37,
-          py38,
-          py39,
-          py310,
-          py311,
-          py312,
-          coverage,
-          flake8
+envlist = py37, py38, py39, py310, py311, py312,
+          coverage, lint
 
 skip_missing_interpreters = true
-isolated_build = True
 
 [testenv]
-deps = pytest
+commands = pytest {posargs}
+description = Run pytest
+
+; there's a weird thing going on with 3.12b2, pip, and pytest
+[testenv:py312]
+ignore_outcome = true 
+basepython = python3.12
 commands = pytest {posargs}
 description = Run pytest
 
 [testenv:coverage]
-deps =
-    coverage
-    pytest
+deps = coverage
 basepython = python3.11
-parallel_show_output=true
 commands =
     coverage run --source={envsitepackagesdir}/pytest_check,tests -m pytest 
     coverage report --fail-under=100 --show-missing
 description = Run pytest, with coverage
 
-[testenv:flake8]
+[testenv:lint]
 skip_install = true
-deps = flake8
-basepython = python3.10
-commands = python -m flake8 --max-line-length=88 src tests examples
-description = Run flake8 over src, test, exampless
+deps = ruff
+basepython = python3.11
+commands = ruff src tests examples
+description = Run ruff over src, test, exampless
 
 [pytest]
 addopts = 


### PR DESCRIPTION
- remove 3.12 from GA since there's a weird thing going on with 3.12b2 and pip. Wait for that to settle
- move version and description from __init__.py ot pyproject.toml
- add ruff linting to tox
- allow 3.12 issue to not block tox outcome