### PR TITLE
Give Python lower bound with ">=" instead of ">"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ readme = "README.md"
 license = {file = "LICENSE.txt"}
 description="A pytest plugin that allows multiple failures per test."
 version = "2.2.0"
-requires-python = ">3.7"
+requires-python = ">=3.7"
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Framework :: Pytest" ,


### PR DESCRIPTION
Fixes #135

This changes the supported Python version specification to `">=3.7"`. Prior to this change it was `">3.7"`, which is equivalent to `">=3.7.1"`, and which I believe does not clearly express intent.

See #135 for details (including on other approaches besides this one).