### PR TITLE
Add short test summary info result message

### DIFF
--- a/examples/test_example_short_test_summary_info.py
+++ b/examples/test_example_short_test_summary_info.py
@@ -1,0 +1,11 @@
+from pytest_check import check
+
+
+def test_baseline():
+    a, b = 1, 2
+    check.equal(a, b)
+
+
+def test_message():
+    a, b = 1, 2
+    check.equal(a, b, f"comment about a={a} != b={b}")

--- a/src/pytest_check/plugin.py
+++ b/src/pytest_check/plugin.py
@@ -3,6 +3,8 @@ import sys
 import pytest
 from _pytest._code.code import ExceptionInfo
 from _pytest.skipping import xfailed_key
+from _pytest.reports import ExceptionChainRepr
+from _pytest._code.code import ExceptionRepr, ReprFileLocation
 
 from . import check_log, check_raises, context_manager, pseudo_traceback
 
@@ -36,8 +38,13 @@ def pytest_runtest_makereport(item, call):
             report.outcome = "failed"
             try:
                 raise AssertionError(report.longrepr)
-            except AssertionError:
+            except AssertionError as e:
                 excinfo = ExceptionInfo.from_current()
+                reprcrash = ReprFileLocation(item.nodeid, 0, str(e))
+                reprtraceback = ExceptionRepr(reprcrash, excinfo)
+                chain_repr = ExceptionChainRepr([(reprtraceback, reprcrash, str(e))])
+                report.longrepr = chain_repr
+
             call.excinfo = excinfo
 
 

--- a/tests/test_short_test_summary_info.py
+++ b/tests/test_short_test_summary_info.py
@@ -1,0 +1,10 @@
+def test_baseline(pytester):
+    pytester.copy_example("examples/test_example_short_test_summary_info.py")
+    result = pytester.runpytest("-k baseline")
+    result.stdout.fnmatch_lines(["*FAILED*-*FAILURE*"])
+
+
+def test_message(pytester):
+    pytester.copy_example("examples/test_example_short_test_summary_info.py")
+    result = pytester.runpytest("-k message")
+    result.stdout.fnmatch_lines(["*FAILED*-*FAILURE*"])


### PR DESCRIPTION
Fixes #133 

add additional info to short test summary info.
The message is FAILURES's first message.

I believe that even if there are multiple error messages, it is sufficient if even one is displayed in the short message

```
FAILURE: check 1 == 2: comment about a=1 != b=2
```

```
============================= test session starts ==============================
platform linux -- Python 3.7.9, pytest-7.4.3, pluggy-1.2.0
rootdir: /tmp/pytest-of-mizubuntu/pytest-75/test_message0
plugins: check-2.2.2
collected 2 items / 1 deselected / 1 selected

test_example_short_test_summary_info.py F                                [100%]

=================================== FAILURES ===================================
_________________________________ test_message _________________________________

FAILURE: check 1 == 2: comment about a=1 != b=2
test_example_short_test_summary_info.py:11 in test_message() -> check.equal(a, b, f"comment about a={a} != b={b}")

------------------------------------------------------------
Failed Checks: 1
=========================== short test summary info ============================
FAILED test_example_short_test_summary_info.py::test_message - FAILURE: check...
======================= 1 failed, 1 deselected in 0.55s ========================
```

