### PR TITLE
Support running pytest with -p no:terminal

### DIFF
--- a/src/pytest_check/plugin.py
+++ b/src/pytest_check/plugin.py
@@ -55,7 +55,7 @@ def pytest_runtest_makereport(item, call):
 def pytest_configure(config):
     # Add some red to the failure output, if stdout can accommodate it.
     isatty = sys.stdout.isatty()
-    color = config.option.color
+    color = getattr(config.option, "color", None)
     check_log.should_use_color = (isatty and color == "auto") or (color == "yes")
 
     # If -x or --maxfail=1, then stop on the first failed check
@@ -69,9 +69,9 @@ def pytest_configure(config):
     check_log._stop_on_fail = stop_on_fail
 
     # Allow for --tb=no to turn off check's pseudo tbs
-    traceback_style = config.getvalue("tbstyle")
+    traceback_style = config.getoption("tbstyle", default=None)
     pseudo_traceback._traceback_style = traceback_style
-    check_log._showlocals = config.getvalue('showlocals')
+    check_log._showlocals = config.getoption("showlocals", default=None)
 
     # grab options
     check_log._default_max_fail = config.getoption("--check-max-fail")


### PR DESCRIPTION
Hi @okken,

Thanks for this package! 

This small PR fixes an issue I encountered when running pytest with `-p no:terminal`. It seems that some of the options the plugin expects don't exist when the terminal is disabled. Here's an example of the issue:

```bash
> pytest -p no:terminal
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/home/rutherford/.env38/lib/python3.8/site-packages/_pytest/main.py", line 266, in wrap_session
INTERNALERROR>     config._do_configure()
INTERNALERROR>   File "/home/rutherford/.env38/lib/python3.8/site-packages/_pytest/config/__init__.py", line 1037, in _do_configure
INTERNALERROR>     self.hook.pytest_configure.call_historic(kwargs=dict(config=self))
INTERNALERROR>   File "/home/rutherford/.env38/lib/python3.8/site-packages/pluggy/_hooks.py", line 514, in call_historic
INTERNALERROR>     res = self._hookexec(self.name, self._hookimpls, kwargs, False)
INTERNALERROR>   File "/home/rutherford/.env38/lib/python3.8/site-packages/pluggy/_manager.py", line 115, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>   File "/home/rutherford/.env38/lib/python3.8/site-packages/pluggy/_callers.py", line 113, in _multicall
INTERNALERROR>     raise exception.with_traceback(exception.__traceback__)
INTERNALERROR>   File "/home/rutherford/.env38/lib/python3.8/site-packages/pluggy/_callers.py", line 77, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/home/rutherford/.env38/lib/python3.8/site-packages/pytest_check/plugin.py", line 58, in pytest_configure
INTERNALERROR>     color = config.option.color
INTERNALERROR> AttributeError: 'Namespace' object has no attribute 'color'
```

I'd be happy to add a test too, but wasn't sure where to put it. Is there an existing module you'd suggest I use?