### PR TITLE
Fix #155, turn off summaries with xdist

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,13 @@ All notable changes to this project  be documented in this file.
 
 -->
 
+## [2.2.5] - 2024-Jan-17
+
+- fix [155](https://github.com/okken/pytest-check/issues/155)
+  - Summaries from 2.2.3 are cool, but don't work with xdist
+  - Turn off summaries while xdist is running
+  - I hope I'm not seeing a pattern here
+
 ## [2.2.4] - 2024-Jan-8
 
 - fix [153](https://github.com/okken/pytest-check/issues/153)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ authors = [{name = "Brian Okken"}]
 readme = "README.md"
 license = {file = "LICENSE.txt"}
 description="A pytest plugin that allows multiple failures per test."
-version = "2.2.4"
+version = "2.2.5"
 requires-python = ">=3.7"
 classifiers = [
     "License :: OSI Approved :: MIT License",

--- a/src/pytest_check/plugin.py
+++ b/src/pytest_check/plugin.py
@@ -1,4 +1,5 @@
 import sys
+import os
 
 import pytest
 from _pytest._code.code import ExceptionInfo
@@ -40,9 +41,11 @@ def pytest_runtest_makereport(item, call):
                 raise AssertionError(report.longrepr)
             except AssertionError as e:
                 excinfo = ExceptionInfo.from_current()
-                if pytest.version_tuple >= (7,3,0):
+                if (pytest.version_tuple >= (7,3,0)
+                        and not os.getenv('PYTEST_XDIST_WORKER')):
                     # Build a summary report with failure reason
                     # Depends on internals of pytest, which changed in 7.3
+                    # Also, doesn't work with xdist
                     #
                     # Example: Before 7.3:
                     #   =========== short test summary info ===========


### PR DESCRIPTION
Fix for #155 

The summary logic doesn't work with xdist.
For now, turn off summaries when xdist is running.