### PR TITLE
Adds type hinting; drops python 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,10 @@ classifiers = [
     'Topic :: Software Development :: Testing',
     'Topic :: Utilities',
 ]
-dependencies = ["pytest>=7.0.0"]
+dependencies = [
+    "pytest >= 7.0.0",
+    "typing-extensions >= 4.12.2, < 5; python_version < '3.11'"
+]
 
 [project.urls]
 Home = "https://github.com/okken/pytest-check"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,12 @@ readme = "README.md"
 license = {file = "LICENSE.txt"}
 description="A pytest plugin that allows multiple failures per test."
 version = "2.4.1"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Framework :: Pytest" ,
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',

--- a/src/pytest_check/__init__.py
+++ b/src/pytest_check/__init__.py
@@ -1,4 +1,5 @@
 import pytest
+from . import check_functions
 
 # make sure assert rewriting happens
 pytest.register_assert_rewrite("pytest_check.check_functions")
@@ -6,10 +7,10 @@ pytest.register_assert_rewrite("pytest_check.check_functions")
 # allow for top level helper function access:
 # import pytest_check
 # pytest_check.equal(1, 1)
-from pytest_check.check_functions import *  # noqa: F401, F402, F403, E402
+from .check_functions import *  # noqa: F401, F402, F403, E402
 
 # allow to know if any_failures due to any previous check
-from pytest_check.check_log import any_failures  # noqa: F401, F402, F403, E402
+from .check_log import any_failures  # noqa: F401, F402, F403, E402
 
 # allow top level raises:
 # from pytest_check import raises
@@ -17,13 +18,13 @@ from pytest_check.check_log import any_failures  # noqa: F401, F402, F403, E402
 #    raise Exception
 # with raises(AssertionError):
 #     assert 0
-from pytest_check.check_raises import raises  # noqa: F401, F402, F403, E402
+from .check_raises import raises  # noqa: F401, F402, F403, E402
 
 # allow for with blocks and assert:
 # from pytest_check import check
 # with check:
 #    assert 1 == 2
-from pytest_check.context_manager import check  # noqa: F401, F402, F403, E402
+from .context_manager import check  # noqa: F401, F402, F403, E402
 
 # allow check.raises()
 setattr(check, "raises", raises)
@@ -33,7 +34,7 @@ setattr(check, "any_failures", any_failures)
 
 # allow check.check as a context manager.
 # weird, but some people are doing it.
-# decprecate this eventually
+# deprecate this eventually
 setattr(check, "check", check)
 
 # allow for helper functions to be part of check context

--- a/src/pytest_check/check_log.py
+++ b/src/pytest_check/check_log.py
@@ -1,25 +1,29 @@
+from __future__ import annotations
+from collections.abc import Iterable
+from typing import Callable
+
 from .pseudo_traceback import _build_pseudo_trace_str
 
 should_use_color = False
 COLOR_RED = "\x1b[31m"
 COLOR_RESET = "\x1b[0m"
-_failures = []
+_failures: list[str] = []
 _stop_on_fail = False
 
 _default_max_fail = None
 _default_max_report = None
 _default_max_tb = 1
 
-_max_fail = _default_max_fail
-_max_report = _default_max_report
+_max_fail: int | None = _default_max_fail
+_max_report: int | None = _default_max_report
 _max_tb = _default_max_tb
 _num_failures = 0
-_fail_function = None
+_fail_function: Callable[[str], None] | None = None
 
 _showlocals = False
 
-def clear_failures():
-    # get's called at the beginning of each test function
+def clear_failures() -> None:
+    # gets called at the beginning of each test function
     global _failures, _num_failures
     global _max_fail, _max_report, _max_tb
     _failures = []
@@ -33,11 +37,13 @@ def any_failures() -> bool:
     return bool(get_failures())
 
 
-def get_failures():
+def get_failures() -> list[str]:
     return _failures
 
 
-def log_failure(msg="", check_str="", tb=None):
+def log_failure(
+    msg: object = "", check_str: str = "", tb: Iterable[str] | None = None
+) -> None:
     global _num_failures
     __tracebackhide__ = True
     _num_failures += 1
@@ -60,7 +66,7 @@ def log_failure(msg="", check_str="", tb=None):
             msg = f"FAILURE: {msg}"
         _failures.append(msg)
         if _fail_function:
-            _fail_function(msg)
+            _fail_function(str(msg))
 
     if _max_fail and (_num_failures >= _max_fail):
         assert_msg = f"pytest-check max fail of {_num_failures} reached"

--- a/src/pytest_check/context_manager.py
+++ b/src/pytest_check/context_manager.py
@@ -1,5 +1,9 @@
+from __future__ import annotations
 import warnings
 import traceback
+from types import TracebackType
+from typing import Callable, Type
+
 from . import check_log
 from .check_log import log_failure
 
@@ -12,18 +16,23 @@ _stop_on_fail = False
 
 
 class CheckContextManager:
-    def __init__(self):
-        self.msg = None
+    def __init__(self) -> None:
+        self.msg: object = None
 
-    def __enter__(self):
+    def __enter__(self) -> "CheckContextManager":
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: Type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool | None:
         __tracebackhide__ = True
         if exc_type is not None and issubclass(exc_type, AssertionError):
             if _stop_on_fail:
                 self.msg = None
-                return
+                return None
             else:
                 fmt_tb = traceback.format_exception(exc_type, exc_val, exc_tb)
                 if self.msg is not None:
@@ -33,27 +42,28 @@ class CheckContextManager:
                 self.msg = None
                 return True
         self.msg = None
+        return None
 
-    def __call__(self, msg=None):
+    def __call__(self, msg: object = None) -> "CheckContextManager":
         self.msg = msg
         return self
 
-    def set_no_tb(self):
+    def set_no_tb(self) -> None:
         warnings.warn(
             "set_no_tb() is deprecated; use set_max_tb(0)", DeprecationWarning
             )
         check_log._max_tb = 0
 
-    def set_max_fail(self, x):
+    def set_max_fail(self, x: int) -> None:
         check_log._max_fail = x
 
-    def set_max_report(self, x):
+    def set_max_report(self, x: int) -> None:
         check_log._max_report = x
 
-    def set_max_tb(self, x):
+    def set_max_tb(self, x: int) -> None:
         check_log._max_tb = x
 
-    def call_on_fail(self, func):
+    def call_on_fail(self, func: Callable[[str], None]) -> None:
         """Experimental feature - may change with any release"""
         check_log._fail_function = func
 

--- a/src/pytest_check/plugin.py
+++ b/src/pytest_check/plugin.py
@@ -1,28 +1,38 @@
 import sys
 import os
+from typing import Generator
 
 import pytest
-from _pytest._code.code import ExceptionInfo
+from pytest import CallInfo, Config, Item, Parser, TestReport
 from _pytest.skipping import xfailed_key
-from _pytest.reports import ExceptionChainRepr
-from _pytest._code.code import ExceptionRepr, ReprFileLocation
+from _pytest._code.code import (
+    ExceptionChainRepr,
+    ExceptionInfo,
+    ExceptionRepr,
+    ReprFileLocation,
+)
+from pluggy import Result
 
 from . import check_log, check_raises, context_manager, pseudo_traceback
+from .context_manager import CheckContextManager
 
 
 @pytest.hookimpl(hookwrapper=True, trylast=True)
-def pytest_runtest_makereport(item, call):
-    outcome = yield
-    report = outcome.get_result()
+def pytest_runtest_makereport(
+    item: Item, call: CallInfo[None]
+) -> Generator[None, Result[TestReport], None]:
+    outcome: Result[TestReport] = yield
+    report: TestReport = outcome.get_result()
 
     num_failures = check_log._num_failures
     failures = check_log.get_failures()
     check_log.clear_failures()
 
     if failures:
-        if item._store[xfailed_key]:
+        xfailed_value = item._store[xfailed_key]
+        if xfailed_value:
             report.outcome = "skipped"
-            report.wasxfail = item._store[xfailed_key].reason
+            report.wasxfail = xfailed_value.reason
         else:
 
             summary = f"Failed Checks: {num_failures}"
@@ -57,8 +67,9 @@ def pytest_runtest_makereport(item, call):
                     e_str = str(e)
                     e_str = e_str.split('FAILURE: ')[1]  # Remove redundant "Failure: "
                     reprcrash = ReprFileLocation(item.nodeid, 0, e_str)
-                    reprtraceback = ExceptionRepr(reprcrash, excinfo)
-                    chain_repr = ExceptionChainRepr([(reprtraceback, reprcrash, str(e))])
+                    # FIXME - the next two lines have broken types
+                    reprtraceback = ExceptionRepr(reprcrash, excinfo)  # type: ignore
+                    chain_repr = ExceptionChainRepr([(reprtraceback, reprcrash, str(e))])  # type: ignore
                     report.longrepr = chain_repr
                 else:  # pragma: no cover
                     # coverage is run on latest pytest
@@ -69,7 +80,7 @@ def pytest_runtest_makereport(item, call):
             call.excinfo = excinfo
 
 
-def pytest_configure(config):
+def pytest_configure(config: Config) -> None:
     # Add some red to the failure output, if stdout can accommodate it.
     isatty = sys.stdout.isatty()
     color = getattr(config.option, "color", None)
@@ -100,12 +111,12 @@ def pytest_configure(config):
 # def test_a(check):
 #    check.equal(a, b)
 @pytest.fixture(name="check")
-def check_fixture():
+def check_fixture() -> CheckContextManager:
     return context_manager.check
 
 
 # add some options
-def pytest_addoption(parser):
+def pytest_addoption(parser: Parser) -> None:
     parser.addoption(
         "--check-max-report",
         action="store",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,14 @@
 [tox]
 # Environments to run by default
-env_list = py39, py310, py311, py312, pytest_earliest, coverage, lint
+env_list =
+    py39
+    py310
+    py311
+    py312
+    pytest_earliest
+    coverage
+    lint
+    mypy_earliest
 
 skip_missing_interpreters = true
 
@@ -12,24 +20,34 @@ wheel_build_env = .pkg
 
 [testenv:coverage]
 deps = coverage
-basepython = python3.12
+base_python = python3.12
 commands =
-    coverage run --source={envsitepackagesdir}/pytest_check,tests -m pytest 
+    coverage run --source={envsitepackagesdir}/pytest_check,tests -m pytest
     coverage report --fail-under=100 --show-missing
 description = Run pytest, with coverage
 
 [testenv:pytest_earliest]
 deps = pytest==7.0.0
-basepython = python3.11
+base_python = python3.11
 commands = pytest {posargs}
 description = Run earliest supported pytest
 
 [testenv:lint]
-skip_install = true
-deps = ruff
-basepython = python3.12
-commands = ruff check src tests examples
-description = Run ruff over src, test, exampless
+deps =
+    mypy
+    ruff
+base_python = python3.12
+commands =
+    ruff check src tests examples
+    mypy --strict --pretty src
+    mypy --pretty tests
+description = Run ruff and mypy over src, test, examples
+
+[testenv:mypy_earliest]
+deps = mypy
+base_python = python3.9
+commands = mypy --strict --pretty src
+description = Run mypy over src for earliest supported python
 
 [pytest]
 addopts =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py38, py39, py310, py311, py312, pytest_earliest, coverage, lint
+# Environments to run by default
+env_list = py39, py310, py311, py312, pytest_earliest, coverage, lint
 
 skip_missing_interpreters = true
 


### PR DESCRIPTION
Closes #163.

Drops support for Python 3.8, which went end of life on 2024-10-07. Supporting it while adding type hints presented additional challenges.

Adds type hints in as narrow a way as I could manage while trying to avoid changes to the API. Also adds mypy checking to the tox file.