### PR TITLE
Fix check ignoring runxfail option

### DIFF
--- a/src/pytest_check/plugin.py
+++ b/src/pytest_check/plugin.py
@@ -20,7 +20,7 @@ def pytest_runtest_makereport(item, call):
     check_log.clear_failures()
 
     if failures:
-        if item._store[xfailed_key]:
+        if item._store[xfailed_key] and not item.config.option.runxfail:
             report.outcome = "skipped"
             report.wasxfail = item._store[xfailed_key].reason
         else:

--- a/tests/test_xfail.py
+++ b/tests/test_xfail.py
@@ -24,3 +24,9 @@ def test_xpass_strict(pytester):
     result = pytester.runpytest("test_example_xfail.py::test_xfail_pass_strict")
     result.assert_outcomes(failed=1)
     result.stdout.fnmatch_lines(["* 1 failed *"])
+
+def test_xfail_runxfail(pytester):
+    pytester.copy_example("examples/test_example_xfail.py")
+    result = pytester.runpytest("--runxfail", "test_example_xfail.py")
+    result.assert_outcomes(passed=2, failed=2)
+    result.stdout.fnmatch_lines(["* 2 failed, 2 passed *"])


### PR DESCRIPTION
Add a check in `pytest_runtest_makereport` that skips `xfail` handling if `runxfail` option is set.

Adds a test for this behaviour.

Resolves #171 