### PR TITLE
Remove flit config from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,3 @@ dev = [
   "tox-uv",
   "build"
 ]
-
-[tool.flit.sdist]
-include = ["changelog.md", "examples", "tests", "tox.ini"]


### PR DESCRIPTION
Might as well cull this obsolete config?