### PR TITLE
Fix pluggy.Result import for pluggy<1.3.0

### DIFF
--- a/src/pytest_check/plugin.py
+++ b/src/pytest_check/plugin.py
@@ -1,6 +1,6 @@
 import sys
 import os
-from typing import Generator
+from typing import Generator, TYPE_CHECKING
 
 import pytest
 from pytest import CallInfo, Config, Item, Parser, TestReport
@@ -11,7 +11,8 @@ from _pytest._code.code import (
     ExceptionRepr,
     ReprFileLocation,
 )
-from pluggy import Result
+if TYPE_CHECKING:  # pragma: no cover
+    from pluggy import Result
 
 from . import check_log, check_raises, context_manager, pseudo_traceback
 from .context_manager import CheckContextManager
@@ -20,8 +21,8 @@ from .context_manager import CheckContextManager
 @pytest.hookimpl(hookwrapper=True, trylast=True)
 def pytest_runtest_makereport(
     item: Item, call: CallInfo[None]
-) -> Generator[None, Result[TestReport], None]:
-    outcome: Result[TestReport] = yield
+) -> "Generator[None, Result[TestReport], None]":
+    outcome: "Result[TestReport]" = yield
     report: TestReport = outcome.get_result()
 
     num_failures = check_log._num_failures

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,10 @@ commands = ruff check src tests examples
 description = Run ruff over src, test, examples
 
 [testenv:mypy]
-deps = mypy
+deps =
+    mypy
+    # pluggy added type checking support in version 1.3.0
+    pluggy>=1.3,<2
 base_python = python3.12
 commands =
     mypy --strict --pretty src
@@ -48,7 +51,9 @@ commands =
 description = Run mypy over src, test
 
 [testenv:mypy_earliest]
-deps = mypy
+deps =
+    mypy
+    pluggy>=1.3,<2
 base_python = python3.9
 commands = mypy --strict --pretty src
 description = Run mypy over src for earliest supported python


### PR DESCRIPTION
pluggy added type checking support and exposed `pluggy.Result` in 1.3.0.

Older `pluggy` versions must be supported as they are supported by `pytest`.

To avoid ImportError in environments with `pluggy<1.3.0` import `pluggy.Result` only during type checking.

Specify `pluggy` version supporting type checking in `mypy` and `mypy_earliest` tox environments.

Closes #176.