### PR TITLE
show path in stacktrace

### DIFF
--- a/src/pytest_check/pseudo_traceback.py
+++ b/src/pytest_check/pseudo_traceback.py
@@ -102,7 +102,6 @@ def _build_pseudo_trace_str(
                    pseudo_trace.append("%-10s = %s" % (name, pformat(val,
                                                                      sort_dicts=False,
                                                                      compact=True)))
-        file = os.path.basename(file)
 
         if color:
             file = f"{COLOR_RED}{file}{COLOR_RESET}"


### PR DESCRIPTION
Before this patch, 
filenames in stacktrace only displayed its basename. This caused that it's not possible to navigate to them clicking on the pycharm terminal.
![image](https://github.com/user-attachments/assets/073b1934-101b-4743-bed9-05542c1fa29e)

after this patch, the relative path is displayed, and it's possible to click on the files
![image](https://github.com/user-attachments/assets/3ee9bff6-5fef-4c52-9abf-05af01a2a576)
