### PR TITLE
export raises & any_failures

### DIFF
--- a/src/pytest_check/__init__.py
+++ b/src/pytest_check/__init__.py
@@ -47,3 +47,5 @@ setattr(check, "check", check)
 #        assert 1 == 2
 for func in check_functions.__all__:  # noqa: F405
     setattr(check, func, getattr(check_functions, func))  # noqa: F405
+
+__all__ = ["raises", "any_failures"]


### PR DESCRIPTION
raises & any_failures exported from top `__init__.py `module so that mypy does not complain that they are not explicitly exported. More info at https://stackoverflow.com/a/79374189/145289

```
test/utils/test_math.py:20: error: Module "pytest_check" does not explicitly export attribute "raises"  [attr-defined]
        with check.raises(ValueError):
```