### PR TITLE
Support getting exception value in raises

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ def test_raises():
     with check.raises(AssertionError):
         x = 3
         assert 1 < x < 4
+
+def test_raises_exception_value():
+    with check.raises(ValueError) as e:
+        raise ValueError("This is a ValueError")
+    assert str(e.value) == "This is a ValueError"
 ```
 
 ## Pseudo-tracebacks

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ def test_raises():
 def test_raises_exception_value():
     with check.raises(ValueError) as e:
         raise ValueError("This is a ValueError")
-    assert str(e.value) == "This is a ValueError"
+    check.equal(str(e.value) == "This is a ValueError")
 ```
 
 ## Pseudo-tracebacks

--- a/changelog.md
+++ b/changelog.md
@@ -24,7 +24,7 @@ All notable changes to this project  be documented in this file.
 
 ### Added
 
-- nothing so far
+- `raises` returns the exception value, so the excpected error message can be verified.
 
 ### Fixed
 

--- a/examples/test_example_raises.py
+++ b/examples/test_example_raises.py
@@ -29,4 +29,4 @@ def test_raises_exception_value():
     with check.raises(ValueError) as e:
         raise ValueError("This is a ValueError")
 
-    assert str(e.value) == "This is a ValueError"
+    check.equal(str(e.value), "This is a ValueError")

--- a/examples/test_example_raises.py
+++ b/examples/test_example_raises.py
@@ -23,3 +23,10 @@ def test_raises_check_level_pass():
     with check.raises(AssertionError):
         x = 4
         assert 1 < x < 3
+
+
+def test_raises_exception_value():
+    with check.raises(ValueError) as e:
+        raise ValueError("This is a ValueError")
+
+    assert str(e.value) == "This is a ValueError"

--- a/src/pytest_check/check_raises.py
+++ b/src/pytest_check/check_raises.py
@@ -81,12 +81,15 @@ class CheckRaisesContext:
     def __init__(self, *expected_excs: type, msg: object = None) -> None:
         self.expected_excs = expected_excs
         self.msg = msg
+        self.value: object | None = None
 
     def __enter__(self) -> "CheckRaisesContext":
         return self
 
     def __exit__(self, exc_type: type, exc_val: object, exc_tb: object) -> bool:
         __tracebackhide__ = True
+
+        self.value = exc_val
         if exc_type is not None and issubclass(exc_type, self.expected_excs):
             # This is the case where an error has occured within the context,
             # but it is the type we're expecting.  Therefore, we return True

--- a/tests/test_raises.py
+++ b/tests/test_raises.py
@@ -224,3 +224,24 @@ def test_raises_with_empty_exception_value():
     with raises(_TestException) as e:
         raise _TestException
     assert str(e.value) == ""
+
+
+def test_raises_with_none_exception_value(testdir):
+    testdir.makepyfile(
+        """
+        from pytest_check import raises
+
+        def test():
+            with raises(AssertionError) as e:
+                x = 1
+                assert x == 1
+            
+            assert str(e.value) == "None"
+    """,
+    )
+
+    result = testdir.runpytest()
+    result.assert_outcomes(failed=1)
+    result.stdout.fnmatch_lines(["FAILURE: None"])
+    result.stdout.no_fnmatch_line("*assert str(e.value) == 'None'*")
+    result.stdout.no_fnmatch_line("*AssertionError: assert 'None'*")

--- a/tests/test_raises.py
+++ b/tests/test_raises.py
@@ -212,3 +212,15 @@ def test_raises_function(testdir):
     result = testdir.runpytest()
     result.assert_outcomes(failed=1)
     result.stdout.fnmatch_lines(["FAILURE: hello, world!"])
+
+
+def test_raises_with_exception_value():
+    with raises(_TestException) as e:
+        raise _TestException("This is a _TestException")
+    assert str(e.value) == "This is a _TestException"
+
+
+def test_raises_with_empty_exception_value():
+    with raises(_TestException) as e:
+        raise _TestException
+    assert str(e.value) == ""


### PR DESCRIPTION
1. Adds the exception value to the `CheckRaisesContext` object coming out of `raises`.
2. Tests and examples were added. 

Resolves https://github.com/okken/pytest-check/issues/185