### PR TITLE
greater/less_equal support numpy scalars

### DIFF
--- a/src/pytest_check/check_functions.py
+++ b/src/pytest_check/check_functions.py
@@ -11,6 +11,7 @@ from typing import (
     TypeVar,
     Union,
 )
+
 if sys.version_info < (3, 10):  # pragma: no cover
     from typing_extensions import ParamSpec
 else:
@@ -52,20 +53,21 @@ __all__ = [
 _P = ParamSpec("_P")
 _T = TypeVar("_T")
 
+
 class _ComparableGreaterThan(Protocol):
-    def __gt__(self, other: Any, /) -> bool: ... # pragma: no cover
+    def __gt__(self, other: ..., /) -> bool: ...  # pragma: no cover
 
 
 class _ComparableGreaterThanOrEqual(Protocol):
-    def __ge__(self, other: Any, /) -> bool: ... # pragma: no cover
+    def __ge__(self, other: ..., /) -> bool: ...  # pragma: no cover
 
 
 class _ComparableLessThan(Protocol):
-    def __lt__(self, other: Any, /) -> bool: ... # pragma: no cover
+    def __lt__(self, other: ..., /) -> bool: ...  # pragma: no cover
 
 
 class _ComparableLessThanOrEqual(Protocol):
-    def __le__(self, other: Any, /) -> bool: ... # pragma: no cover
+    def __le__(self, other: ..., /) -> bool: ...  # pragma: no cover
 
 
 def check_func(func: Callable[_P, _T]) -> Callable[_P, bool]:
@@ -194,7 +196,8 @@ def is_not_in(a: _T, b: Container[_T], msg: str = "") -> bool:
         return False
 
 
-_TypeTuple = Union[type, tuple['_TypeTuple', ...]]
+_TypeTuple = Union[type, tuple["_TypeTuple", ...]]
+
 
 def is_instance(a: object, b: _TypeTuple, msg: str = "") -> bool:
     __tracebackhide__ = True
@@ -314,7 +317,7 @@ def between_equal(
     b: _ComparableLessThanOrEqual,
     a: _ComparableLessThanOrEqual,
     c: object,
-    msg:str = "",
+    msg: str = "",
 ) -> bool:
     __tracebackhide__ = True
     return between(b, a, c, msg, ge=True, le=True)


### PR DESCRIPTION
After numpy 2.2/2.3, their type hints make mypy fail with code such as `check.greater_equal(np.int8(3), 1) `
Can be reproduced with python 3.14, mypy 1.18.2 & pytest-check 2.6.0

```python

test.py:189: error: Argument 1 to "greater_equal" has incompatible type "float64"; expected
"_ComparableGreaterThanOrEqual"  [arg-type]
                check.greater_equal(np.int8(3), 1)
                                    ^~~~~~~~
test.py:189: note: Following member(s) of "float64" have conflicts:
test.py:189: note:     Expected:
test.py:189: note:         def __ge__(self, Any, /) -> bool
test.py:189: note:     Got:
test.py:189: note:         @overload
test.py:189: note:         def __ge__(self, complex | number[Any, int | float | complex] | numpy.bool[builtins.bool], /) -> numpy.bool[builtins.bool]
test.py:189: note:         @overload
test.py:189: note:         def __ge__(self, _SupportsArray[dtype[numpy.bool[builtins.bool] | number[Any, int | float | complex]]] | _NestedSequence[_SupportsArray[dtype[numpy.bool[builtins.bool] | number[Any, int | float | complex]]]] | complex | _NestedSequence[complex] | _NestedSequence[_SupportsLE], /) -> ndarray[tuple[Any, ...], dtype[numpy.bool[builtins.bool]]]
test.py:189: note:         @overload
test.py:189: note:         def __ge__(self, _SupportsLE, /) -> numpy.bool[builtins.bool]
Found 1 error in 1 file (checked 1 source file)
```