### PR TITLE
Update __all__ to include 'check' in pytest_check module

### DIFF
--- a/src/pytest_check/__init__.py
+++ b/src/pytest_check/__init__.py
@@ -48,4 +48,4 @@ setattr(check, "check", check)
 for func in check_functions.__all__:  # noqa: F405
     setattr(check, func, getattr(check_functions, func))  # noqa: F405
 
-__all__ = ["raises", "any_failures"]
+__all__ = ["check", "raises", "any_failures"]


### PR DESCRIPTION
Fixes syntax checking error:
> "check" is not exported from module "pytest_check"
>   Import from "pytest_check.context_manager" insteadPylancereportPrivateImportUsage
> (variable) check: CheckContextManager

Resolves #190