### PR TITLE
Use contextvars instead of module globals for check state (thread-safety)

### DIFF
--- a/src/pytest_check/check_log.py
+++ b/src/pytest_check/check_log.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+import contextvars
+import threading
 from collections.abc import Iterable
 from typing import Callable
 
@@ -7,40 +9,113 @@ from .pseudo_traceback import _build_pseudo_trace_str, _build_single_line_trace_
 should_use_color: bool = False
 COLOR_RED = "\x1b[31m"
 COLOR_RESET = "\x1b[0m"
-_failures: list[str] = []
 _stop_on_fail = False
 
+# Session-wide config, set once in pytest_configure() before any test runs.
+# Safe to keep as plain globals - never mutated per-test.
 _default_max_fail = None
 _default_max_report = None
 _default_max_tb: int = 1
 _default_max_tb_line: int | None = None
 
-_max_fail: int | None = _default_max_fail
-_max_report: int | None = _default_max_report
-_max_tb: int = _default_max_tb
-_max_tb_line: int | None = _default_max_tb_line
-_num_failures = 0
-_fail_function: Callable[[str], None] | None = None
-
 _showlocals: bool = False
 
-# Track checks with xfail reasons
-_xfailed_failure: str | None = None
+
+class _CheckState:
+    """Failure bookkeeping for a single, currently-running test."""
+
+    def __init__(self) -> None:
+        self.failures: list[str] = []
+        self.num_failures = 0
+        self.max_fail: int | None = _default_max_fail
+        self.max_report: int | None = _default_max_report
+        self.max_tb: int = _default_max_tb
+        self.max_tb_line: int | None = _default_max_tb_line
+        self.fail_function: Callable[[str], None] | None = None
+        # Track checks with xfail reasons
+        self.xfailed_failure: str | None = None
+
+
+# One _CheckState per *currently executing test*, not per OS thread.
+#
+# A plain threading.local() would isolate state between OS threads, which is
+# exactly what's needed when a thread-based parallel runner (pytest-swarm,
+# pytest-run-parallel, pytest-freethreaded, ...) executes several *different*
+# tests concurrently in separate worker threads - each worker must get its
+# own failure list.
+#
+# But pytest-check also documents and tests a different pattern: a *single*
+# test spawning helper threads (via threading.Thread or ThreadPoolExecutor)
+# and expecting check failures raised inside them to count against that one
+# test (see tests/test_thread.py). A bare threading.local() breaks that,
+# because the helper thread would get its own empty state that the main
+# thread's test report never sees.
+#
+# contextvars.ContextVar reconciles both: each new OS thread starts with its
+# own empty Context (so concurrent top-level test threads are isolated, same
+# as threading.local would give us), while _propagate_context_to_new_threads()
+# below makes any thread spawned *from within* a running test inherit a
+# reference to that same test's _CheckState - so nested helper threads keep
+# working exactly as before.
+_state_var: contextvars.ContextVar[_CheckState] = contextvars.ContextVar(
+    "pytest_check_state"
+)
+
+
+def _current_state() -> _CheckState:
+    try:
+        return _state_var.get()
+    except LookupError:
+        state = _CheckState()
+        _state_var.set(state)
+        return state
+
+
+_propagation_installed = False
+
+
+def _propagate_context_to_new_threads() -> None:
+    """Make new threads inherit the spawning thread's contextvars.Context.
+
+    threading.Thread (and, transitively, ThreadPoolExecutor workers on their
+    first task) normally start with a fresh, empty Context, so a ContextVar
+    set in the parent thread would not be visible to code running in the
+    child thread. Patching Thread.start() to run the thread's body inside a
+    copy of the *calling* thread's current Context restores the "helper
+    thread's checks belong to the test that spawned it" behaviour that
+    pytest-check's global-state implementation used to provide for free.
+
+    This is a process-wide, one-time patch applied when pytest-check is
+    loaded; it only affects contextvars propagation and has no effect on
+    unrelated thread behaviour.
+    """
+    global _propagation_installed
+    if _propagation_installed:
+        return
+    _propagation_installed = True
+
+    original_start = threading.Thread.start
+
+    def start_with_context(self: threading.Thread) -> None:
+        ctx = contextvars.copy_context()
+        original_run = self.run
+
+        def run_in_context() -> None:
+            ctx.run(original_run)
+
+        self.run = run_in_context  # type: ignore[method-assign]
+        original_start(self)
+
+    threading.Thread.start = start_with_context  # type: ignore[method-assign]
+
+
+_propagate_context_to_new_threads()
 
 
 def clear_failures() -> None:
     # gets called at the beginning of each test function
-    global _failures, _num_failures
-    global _max_fail, _max_report, _max_tb, _max_tb_line
-    global _xfailed_failure, _fail_function
-    _failures = []
-    _num_failures = 0
-    _max_fail = _default_max_fail
-    _max_report = _default_max_report
-    _max_tb = _default_max_tb
-    _max_tb_line = _default_max_tb_line
-    _fail_function = None
-    _xfailed_failure = None
+    state = _CheckState()
+    _state_var.set(state)
 
 
 def any_failures() -> bool:
@@ -48,7 +123,11 @@ def any_failures() -> bool:
 
 
 def get_failures() -> list[str]:
-    return _failures
+    return _current_state().failures
+
+
+def get_num_failures() -> int:
+    return _current_state().num_failures
 
 
 def log_failure(
@@ -57,23 +136,25 @@ def log_failure(
     tb: Iterable[str] | None = None,
     xfail: str | None = None,
 ) -> None:
-    global _num_failures
-    global _xfailed_failure
     __tracebackhide__ = True
-    _num_failures += 1
+    state = _current_state()
+    state.num_failures += 1
 
     msg = str(msg).strip()
 
     if check_str:
         msg = f"{msg}: {check_str}"
 
-    if (_max_report is None) or (_num_failures <= _max_report):
-        if _num_failures <= _max_tb:
+    if (state.max_report is None) or (state.num_failures <= state.max_report):
+        if state.num_failures <= state.max_tb:
             pseudo_trace_str = _build_pseudo_trace_str(
                 _showlocals, tb, should_use_color
             )
             msg = f"{msg}\n{pseudo_trace_str}"
-        elif _max_tb_line is not None and _num_failures <= _max_tb_line:
+        elif (
+            state.max_tb_line is not None
+            and state.num_failures <= state.max_tb_line
+        ):
             pseudo_trace_str = _build_single_line_trace_str(tb, should_use_color)
             if pseudo_trace_str:
                 msg = f"{msg}, {pseudo_trace_str}"
@@ -82,17 +163,17 @@ def log_failure(
             msg = f"{COLOR_RED}FAILURE: {COLOR_RESET}{msg}"
         else:
             msg = f"FAILURE: {msg}"
-        _failures.append(msg)
+        state.failures.append(msg)
 
-        if xfail and _xfailed_failure is None:
-            _xfailed_failure = xfail
+        if xfail and state.xfailed_failure is None:
+            state.xfailed_failure = xfail
 
-        if _fail_function:
-            _fail_function(str(msg))
+        if state.fail_function:
+            state.fail_function(str(msg))
 
-    if _max_fail and (_num_failures >= _max_fail):
-        assert_msg = f"pytest-check max fail of {_num_failures} reached"
-        assert _num_failures < _max_fail, assert_msg
+    if state.max_fail and (state.num_failures >= state.max_fail):
+        assert_msg = f"pytest-check max fail of {state.num_failures} reached"
+        assert state.num_failures < state.max_fail, assert_msg
 
     if _stop_on_fail:
         assert False, "Stopping on first failure"
@@ -100,4 +181,4 @@ def log_failure(
 
 def get_xfailed_failure() -> str | None:
     """Return the xfail reason for the first check that failed with xfail."""
-    return _xfailed_failure
+    return _current_state().xfailed_failure

--- a/src/pytest_check/context_manager.py
+++ b/src/pytest_check/context_manager.py
@@ -56,19 +56,19 @@ class CheckContextManager:
         warnings.warn(
             "set_no_tb() is deprecated; use set_max_tb(0)", DeprecationWarning
         )
-        check_log._max_tb = 0
+        check_log._current_state().max_tb = 0
 
     def set_max_fail(self, x: int) -> None:
-        check_log._max_fail = x
+        check_log._current_state().max_fail = x
 
     def set_max_report(self, x: int) -> None:
-        check_log._max_report = x
+        check_log._current_state().max_report = x
 
     def set_max_tb(self, x: int) -> None:
-        check_log._max_tb = x
+        check_log._current_state().max_tb = x
 
     def call_on_fail(self, func: Callable[[str], None]) -> None:
         """Experimental feature - may change with any release"""
-        check_log._fail_function = func
+        check_log._current_state().fail_function = func
 
 check = CheckContextManager()

--- a/src/pytest_check/plugin.py
+++ b/src/pytest_check/plugin.py
@@ -45,7 +45,7 @@ def pytest_runtest_makereport(
     outcome: "Result[TestReport]" = yield
     report: TestReport = outcome.get_result()
 
-    num_failures = check_log._num_failures
+    num_failures = check_log.get_num_failures()
     failures = check_log.get_failures()
     check_log.clear_failures()
 

--- a/tests/test_pseudo_tb_corner_cases.py
+++ b/tests/test_pseudo_tb_corner_cases.py
@@ -109,8 +109,8 @@ def test_log_failure_handles_empty_single_line_trace_path(monkeypatch):
         check_log, "_build_single_line_trace_str", lambda *_args, **_kwargs: ""
     )
 
-    check_log._max_tb = 1
-    check_log._max_tb_line = 2
+    check_log._current_state().max_tb = 1
+    check_log._current_state().max_tb_line = 2
 
     check_log.log_failure("first")
     check_log.log_failure("second")


### PR DESCRIPTION
  Title:                                                                                                                                                                                                    
  Make check state thread-safe with contextvars instead of module globals                                                                                                                                   
                                                                                                                                                                                                            
  Body:                                                                                                                                                                                                     
  ## Problem                                                                                                                                                                                                
                                                                                                                                                                                                            
  `pytest_check.check_log` keeps all per-test bookkeeping (`_failures`,                                                                                                                                     
  `_num_failures`, `_max_fail`, `_max_report`, `_max_tb`, `_max_tb_line`,                                                                                                                                   
  `_fail_function`, `_xfailed_failure`) in plain module-level globals. This                                                                                                                                 
  implicitly assumes pytest only ever runs one test's call phase at a time in                                                                                                                               
  the process, which is true for pytest's default serial runner and for                                                                                                                                     
  pytest-xdist (separate *processes*, so each has its own globals).                                                                                                                                         
                                                                                                                                                                                                            
  It is not true for the growing family of thread-based parallel runners that                                                                                                                               
  execute several tests' bodies concurrently inside *one* process:                                                                                                                                          
  [pytest-swarm](https://github.com/dpadninja/pytest-swarm),                                                                                                                                                      
  [pytest-run-parallel](https://github.com/Quansight-Labs/pytest-run-parallel),                                                                                                                             
  [pytest-freethreaded](https://github.com/tonybaloney/pytest-freethreaded),                                                                                                                                
  pytest-threadpool, and pytest-parallel's threading mode. Under any of these,                                                                                                                              
  two tests' `check.equal()` calls race on the same global list, and failure                                                                                                                                
  counts/messages get attributed to the wrong test (or lost).                                                                                                                                               
                                                                                                                                                                                                            
  Reproduced with two threads logging 3 and 5 failures concurrently:                                                                                                                                        
  before this patch, results come back mixed (e.g. `{3: 3, 5: 8}`) on every                                                                                                                                 
  run; end-to-end with pytest-swarm running 8 parametrized tests expecting                                                                                                                                  
  0-7 failures each, the unpatched plugin reports duplicate/zero/missing                                                                                                                                    
  counts (`Failed Checks: 0` on a test that should pass, `4` reported twice,                                                                                                                                
  `7` never reported). 