### PR TITLE
Fail missing expected exceptions when stopping on first failure

### DIFF
--- a/src/pytest_check/check_raises.py
+++ b/src/pytest_check/check_raises.py
@@ -108,7 +108,7 @@ class CheckRaisesContext:
             # context.
             return True
 
-        if not _stop_on_fail:
+        if not _stop_on_fail or exc_type is None:
             # Returning something falsey here will cause the context
             # manager to *not* suppress an exception not in
             # `expected_excs`, thus allowing the higher-level Pytest

--- a/tests/test_raises.py
+++ b/tests/test_raises.py
@@ -310,3 +310,28 @@ def test_raises_custom_msg(run_example_test):
     if version.parse(pytest.__version__) >= version.parse("7.3.0"):  # pragma: no branch
         expected_line += " - Custom error message"
     result.stdout.fnmatch_lines([expected_line])
+
+
+@pytest.mark.parametrize("style", ["context", "callable"])
+def test_raises_missing_exception_with_exitfirst(
+    pytester: pytest.Pytester, style: str
+) -> None:
+    invocation = (
+        "with raises(ValueError):\n        pass"
+        if style == "context"
+        else "raises(ValueError, lambda: None)"
+    )
+    pytester.makepyfile(
+        "from pathlib import Path\n"
+        "from pytest_check import raises\n\n"
+        "def test_missing_exception():\n"
+        f"    {invocation}\n"
+        '    Path("continued").touch()\n\n'
+        "def test_next():\n"
+        '    Path("next-test").touch()\n'
+    )
+    result = pytester.runpytest_subprocess("-x")
+    result.assert_outcomes(failed=1)
+    assert result.ret == 1
+    assert not (pytester.path / "continued").exists()
+    assert not (pytester.path / "next-test").exists()


### PR DESCRIPTION
## Problem and change

With pytest -x, check.raises(ValueError) silently passes if its body or callable raises nothing. __exit__ returns False without recording a failure; False cannot create an exception where none exists. Route that case through existing log_failure, whose stop-on-fail behavior raises. The two subprocess regressions assert failure exit 1 and that neither the remainder nor the next test executes.

## Verification

Original exact regressions: 2 failed (exit 1); both child sessions incorrectly reported 2 passed and exit 0. Fixed: 2 passed (exit 0); child sessions report 1 failed and exit 1. Full suite: 107 passed, 1 skipped (missing optional pytest-reportlog), exit 0. Project-pinned ruff 0.15.0 check passes; newer ruff 0.16.6 reports six pre-existing style findings, so pinned configuration was used. Diff check passes.

## Limits

Only macOS Python 3.12.13 / pytest 9.1.1 tested. Optional pytest-reportlog test skipped. Open PR #202 changes concurrency state in other files and does not address this raises failure; #204 concerns traceback paths.

AI assistance: OpenAI Codex drafted and checked this change; all reported commands were run locally.
